### PR TITLE
Feature/implement logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `corva.Logger` object, that should be used for app logging.
+- `LOG_THRESHOLD_MESSAGE_SIZE` and `LOG_THRESHOLD_MESSAGE_COUNT`
+env variables, that should be used to configure logging.
+
 
 ## [0.0.16] - 2021-04-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -269,16 +269,18 @@ other operations with data.
 ## Logging
 As apps are executed very frequently
 (once a second or so),
-unlimited logging can lead to unexpected huge bills.
+unlimited logging can lead to huge amounts of data.
 
 The SDK provides a `Logger` object,
 which is a safe way for logging in apps.
 
 The `Logger` is a `logging.Logger` instance
-and so should be used like every Python logger.
+and should be used like every other Python logger.
 
-The `Logger` protects from huge bills
-by having following features:
+The `Logger` has following features:
+1. Log messages are injected with contextual information,
+   which makes it easy to filter through logs
+   while debugging issues.
 1. Log message length is limited. 
    Too long messages are truncated to not exceed the limit. 
    Set by `LOG_THRESHOLD_MESSAGE_SIZE` env variable. 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The `Logger` has following features:
    Set by `LOG_THRESHOLD_MESSAGE_COUNT` env variable.
    Default value is `15`.
 3. Logging level can be set using `LOG_LEVEL` env variable.
-   Default value is `WARN`.
+   Default value is `INFO`.
 
 #### Logger usage example
 

--- a/README.md
+++ b/README.md
@@ -311,40 +311,6 @@ def lambda_handler(event, context):
     return Corva(context).stream(fn=stream_app, event=event)
 ```
 
-#### How to set the best logging env variables?
-To decide which values for logging env variables
-will be the best for the app you should know
-how logging bill is calculated. 
-
-Generally, the more you log - the more you pay.
-
-Logging bill for one app  can be calculated like this:
-
-Inputs:
-- Logging bill is received once a month
-  and app is triggered once a second
-  ```python3
-  # 60seconds * 60minutes * 24hours * 31days
-  app_triggers_per_month = 2678400
-  ```
-- Max logged GBs per trigger
-  ```python3
-  # LOG_THRESHOLD_MESSAGE_SIZE * LOG_THRESHOLD_MESSAGE_COUNT / (10**9)
-  max_log_gb_per_trigger = 0.000015 
-  ```
-- Price per GB of logged data
-  ```python3
-  # dollars
-  price_per_gb = 0.5
-  ```
-Output:
-```python3
-# app_triggers_per_month * max_log_gb_per_trigger * price_per_gb
-approx_logging_bill = 20  # dollars
-```
-So, using default values
-you will pay 20 dollars a month in the worst case.
-
 
 ## Testing
 

--- a/src/corva/__init__.py
+++ b/src/corva/__init__.py
@@ -9,11 +9,13 @@ from .models.stream.stream import (
 )
 from .models.task import TaskEvent
 from .state.redis_state import RedisState as Cache
+from .logger import DEFAULT_LOGGER as Logger
 
 __all__ = [
     'Api',
     'Cache',
     'Corva',
+    'Logger',
     'ScheduledEvent',
     'StreamDepthEvent',
     'StreamDepthRecord',

--- a/src/corva/__init__.py
+++ b/src/corva/__init__.py
@@ -9,7 +9,7 @@ from .models.stream.stream import (
 )
 from .models.task import TaskEvent
 from .state.redis_state import RedisState as Cache
-from .logger import DEFAULT_LOGGER as Logger
+from .logger import CORVA_LOGGER as Logger
 
 __all__ = [
     'Api',

--- a/src/corva/application.py
+++ b/src/corva/application.py
@@ -16,6 +16,7 @@ class Corva:
     Attributes:
         cache_settings: custom cache params.
         api: Api instance.
+        aws_request_id: aws request id received in context
     """
 
     def __init__(
@@ -34,6 +35,7 @@ class Corva:
         """
 
         self.api = get_api(context=context, settings=SETTINGS, timeout=timeout)
+        self.aws_request_id = context.aws_request_id
         self.cache_settings = cache_settings or {}
 
     def stream(
@@ -59,6 +61,7 @@ class Corva:
                 settings=SETTINGS.copy(),
                 api=self.api,
                 cache_settings=self.cache_settings,
+                aws_request_id=self.aws_request_id,
             )
 
             results.append(stream_runner(fn=fn, context=ctx))
@@ -84,6 +87,7 @@ class Corva:
                 settings=SETTINGS.copy(),
                 api=self.api,
                 cache_settings=self.cache_settings,
+                aws_request_id=self.aws_request_id,
             )
 
             results.append(scheduled_runner(fn=fn, context=ctx))
@@ -106,6 +110,7 @@ class Corva:
             settings=SETTINGS.copy(),
             api=self.api,
             cache_settings=self.cache_settings,
+            aws_request_id=self.aws_request_id,
         )
 
         result = task_runner(fn=fn, context=ctx)

--- a/src/corva/application.py
+++ b/src/corva/application.py
@@ -16,7 +16,7 @@ class Corva:
     Attributes:
         cache_settings: custom cache params.
         api: Api instance.
-        aws_request_id: aws request id received in context
+        aws_request_id: aws request id from the lambda context
     """
 
     def __init__(

--- a/src/corva/configuration.py
+++ b/src/corva/configuration.py
@@ -11,7 +11,8 @@ class Settings(pydantic.BaseSettings):
 
     # logger
     LOG_LEVEL: str = 'WARN'
-    LOG_MAX_CHARS: int = 15000
+    LOG_THRESHOLD_MESSAGE_SIZE: int = 1000
+    LOG_THRESHOLD_MESSAGE_COUNT: int = 15
 
     # company and app
     APP_KEY: str  # <provider-name-with-dashes>.<app-name-with-dashes>

--- a/src/corva/configuration.py
+++ b/src/corva/configuration.py
@@ -11,6 +11,7 @@ class Settings(pydantic.BaseSettings):
 
     # logger
     LOG_LEVEL: str = 'WARN'
+    LOG_MAX_CHARS: int = 15000
 
     # company and app
     APP_KEY: str  # <provider-name-with-dashes>.<app-name-with-dashes>

--- a/src/corva/configuration.py
+++ b/src/corva/configuration.py
@@ -10,7 +10,7 @@ class Settings(pydantic.BaseSettings):
     CACHE_URL: str
 
     # logger
-    LOG_LEVEL: str = 'WARN'
+    LOG_LEVEL: str = 'INFO'
     LOG_THRESHOLD_MESSAGE_SIZE: int = 1000
     LOG_THRESHOLD_MESSAGE_COUNT: int = 15
 

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -28,7 +28,7 @@ def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optiona
     # add formatter
     corva_formatter = logging.Formatter(
         '%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
-        '%(asset_id)s %(app_connection_id)s | %(message)s\n',
+        '%(asset_id)s %(app_connection_id)s| %(message)s\n',
         '%Y-%m-%dT%H:%M:%S',
     )
     corva_handler.setFormatter(corva_formatter)
@@ -59,7 +59,7 @@ class CorvaLoggerFilter(logging.Filter):
         self.aws_request_id = aws_request_id
         self.asset_id = f'ASSET={asset_id}'
         self.app_connection_id = (
-            '' if app_connection_id is None else f'AC={app_connection_id}'
+            '' if app_connection_id is None else f'AC={app_connection_id} '
         )
 
     def filter(self, record):

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -9,18 +9,18 @@ from unittest import mock
 from corva.configuration import SETTINGS
 
 LOGGER_NAME = 'corva'
-DEFAULT_LOGGER = logging.getLogger(LOGGER_NAME)
-DEFAULT_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
-DEFAULT_LOGGER.propagate = False  # do not pass messages to ancestor loggers
+CORVA_LOGGER = logging.getLogger(LOGGER_NAME)
+CORVA_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
+CORVA_LOGGER.propagate = False  # do not pass messages to ancestor loggers
 logging.Formatter.converter = time.gmtime  # log time as UTC
 
 
 @contextlib.contextmanager
 def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optional[int]):
-    DEFAULT_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
+    CORVA_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
 
     corva_handler = CorvaLoggerHandler(
-        max_chars=SETTINGS.LOG_MAX_CHARS, logger=DEFAULT_LOGGER
+        max_chars=SETTINGS.LOG_MAX_CHARS, logger=CORVA_LOGGER
     )
 
     corva_handler.setLevel(SETTINGS.LOG_LEVEL)
@@ -43,7 +43,7 @@ def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optiona
     )
     corva_handler.addFilter(corva_filter)
 
-    with mock.patch.object(DEFAULT_LOGGER, 'handlers', [corva_handler]):
+    with mock.patch.object(CORVA_LOGGER, 'handlers', [corva_handler]):
         yield
 
 

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -10,24 +10,15 @@ from corva.configuration import SETTINGS
 
 LOGGER_NAME = 'corva'
 DEFAULT_LOGGER = logging.getLogger(LOGGER_NAME)
-
+DEFAULT_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
+DEFAULT_LOGGER.propagate = False  # do not pass messages to ancestor loggers
 logging.Formatter.converter = time.gmtime  # log time as UTC
-logging.config.dictConfig(
-    {
-        'version': 1,  # schema version - required key
-        'disable_existing_loggers': False,  # do not disable existing non-root loggers
-        'loggers': {
-            LOGGER_NAME: {
-                'level': SETTINGS.LOG_LEVEL,
-                'propagate': False,  # do not pass messages to ancestor loggers
-            }
-        },
-    }
-)
 
 
 @contextlib.contextmanager
 def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optional[int]):
+    DEFAULT_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
+
     corva_handler = CorvaLoggerHandler(
         max_chars=SETTINGS.LOG_MAX_CHARS, logger=DEFAULT_LOGGER
     )

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -81,7 +81,7 @@ class CorvaLoggerHandler(logging.Handler):
     def __init__(self, max_chars: int, logger: logging.Logger):
         logging.Handler.__init__(self)
 
-        self.stream: IO[str] = sys.stdout
+        self.stream = sys.stdout
         self.max_chars = max_chars
         self.logger = logger
         self.logged_chars = 0

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -3,7 +3,7 @@ import logging
 import logging.config
 import sys
 import time
-from typing import IO, Optional
+from typing import Optional
 from unittest import mock
 
 from corva.configuration import SETTINGS

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -54,7 +54,7 @@ class CorvaLoggerFilter(logging.Filter):
         self,
         aws_request_id: str,
         asset_id: int,
-        app_connection_id: Optional[int] = None,
+        app_connection_id: Optional[int],
     ):
         logging.Filter.__init__(self)
 

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -1,58 +1,117 @@
-from logging import LoggerAdapter, Formatter, getLogger
-from logging.config import dictConfig
-from time import gmtime
+import contextlib
+import logging
+import logging.config
+import sys
+import time
+from typing import Optional
+from unittest import mock
 
 from corva.configuration import SETTINGS
 
-
-class UtcFormatter(Formatter):
-    converter = gmtime
+LOGGER_NAME = 'corva'
 
 
-dictConfig(
+@contextlib.contextmanager
+def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optional[int]):
+    logger = logging.getLogger(LOGGER_NAME)
+
+    corva_handler = CorvaLoggerHandler(max_chars=SETTINGS.LOG_MAX_CHARS, logger=logger)
+
+    corva_handler.setLevel(SETTINGS.LOG_LEVEL)
+
+    # add formatter
+    logging.Formatter.converter = time.gmtime  # log time as UTC
+    corva_formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
+        '%(asset_id)s %(app_connection_id)s | %(message)s\n',
+        '%Y-%m-%dT%H:%M:%S',
+    )
+    corva_handler.setFormatter(corva_formatter)
+
+    # add filter
+    corva_filter = CorvaLoggerFilter(
+        aws_request_id=aws_request_id,
+        asset_id=asset_id,
+        app_connection_id=app_connection_id,
+    )
+    corva_handler.addFilter(corva_filter)
+
+    with mock.patch.object(logger, 'handlers', [corva_handler]):
+        yield
+
+
+class CorvaLoggerFilter(logging.Filter):
+    def __init__(
+        self,
+        aws_request_id: str,
+        asset_id: int,
+        app_connection_id: Optional[int] = None,
+    ):
+        logging.Filter.__init__(self)
+
+        self.aws_request_id = aws_request_id
+        self.asset_id = f'ASSET={asset_id}'
+        self.app_connection_id = (
+            '' if app_connection_id is None else f'AC={app_connection_id}'
+        )
+
+    def filter(self, record):
+        record.aws_request_id = self.aws_request_id
+        record.asset_id = self.asset_id
+        record.app_connection_id = self.app_connection_id
+
+        return True
+
+
+class CorvaLoggerHandler(logging.Handler):
+    def __init__(self, max_chars: int, logger: logging.Logger):
+        logging.Handler.__init__(self)
+
+        self.max_chars = max_chars
+        self.logger = logger
+        self.logged_chars = 0
+        self.logging_enabled = True
+        self.warning_logged = False
+
+    def emit(self, record):
+        if not self.logging_enabled:
+            return
+
+        msg = self.format(record)
+
+        self.logged_chars += len(msg)
+
+        if self.logged_chars < self.max_chars:
+            sys.stdout.write(msg)
+            return
+
+        if self.warning_logged:
+            self.logging_enabled = False
+            sys.stdout.write(msg)
+            return
+
+        msg = f'{msg[: len(msg) - (self.logged_chars - self.max_chars - 1)]}\n'
+        sys.stdout.write(msg)
+
+        self.warning_logged = True
+        self.logger.warning(
+            f'Disabling the logging as maximum number of logged characters was reached: '
+            f'{self.max_chars}.'
+        )
+
+
+logging.config.dictConfig(
     {
-        'version': 1,
-        'formatters': {
-            'default': {
-                '()': UtcFormatter,
-                'format': '%(asctime)s %(name)-5s %(levelname)-5s %(message)s'
-            }
-        },
-        'handlers': {
-            'stream': {
-                'class': 'logging.StreamHandler',
-                'level': SETTINGS.LOG_LEVEL,
-                'formatter': 'default',
-                'stream': 'ext://sys.stdout'
-            }
-        },
+        'version': 1,  # schema version - required key
+        'disable_existing_loggers': False,  # do not disable existing non-root loggers
         'loggers': {
-            'main': {
+            LOGGER_NAME: {
                 'level': SETTINGS.LOG_LEVEL,
-                'handlers': ['stream'],
-                'propagate': False
+                'propagate': False,  # do not pass messages to ancestor loggers
             }
-        }
+        },
     }
 )
 
 
-class LogAdapter(LoggerAdapter):
-    extra_fields = []
-
-    def process(self, msg, kwargs):
-        message_parts = [
-            f'[{field}:{self.extra[field]}]'
-            for field in self.extra_fields
-            if field in self.extra
-        ]
-        message_parts.append(str(msg))
-        message = ' '.join(message_parts)
-        return message, kwargs
-
-
-class AppLogger(LogAdapter):
-    extra_fields = ['asset_id']
-
-
-DEFAULT_LOGGER = getLogger('main')
+DEFAULT_LOGGER = logging.getLogger('main')

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -106,7 +106,7 @@ class CorvaLoggerHandler(logging.Handler):
         self.logger = logger
         self.placeholder = placeholder
 
-        self.warning_logged = False
+        self.logging_warning = False
         # one extra message to log the warning
         self.residue_message_count = self.max_message_count + 1
 
@@ -114,18 +114,18 @@ class CorvaLoggerHandler(logging.Handler):
         if self.residue_message_count == 0:
             return
 
-        if self.residue_message_count == 1 and not self.warning_logged:
-            self.warning_logged = True
+        if self.residue_message_count > 1 or self.logging_warning:
+            self.log(message=self.format(record))
+            self.residue_message_count -= 1
+
+        if self.residue_message_count == 1:
+            self.logging_warning = True
             self.logger.warning(
                 f'Disabling the logging as maximum number of logged messages was reached: '
                 f'{self.max_message_count}.'
             )
-            return
 
-        self.log(message=self.format(record))
-        self.residue_message_count -= 1
-
-    def format(self, record: LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> str:
         message = super().format(record)
 
         extra_chars_count = len(message) - self.max_message_size

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -11,7 +11,7 @@ from corva.configuration import SETTINGS
 LOGGER_NAME = 'corva'
 DEFAULT_LOGGER = logging.getLogger(LOGGER_NAME)
 
-
+logging.Formatter.converter = time.gmtime  # log time as UTC
 logging.config.dictConfig(
     {
         'version': 1,  # schema version - required key
@@ -35,7 +35,6 @@ def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optiona
     corva_handler.setLevel(SETTINGS.LOG_LEVEL)
 
     # add formatter
-    logging.Formatter.converter = time.gmtime  # log time as UTC
     corva_formatter = logging.Formatter(
         '%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
         '%(asset_id)s %(app_connection_id)s | %(message)s\n',

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -27,8 +27,9 @@ def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optiona
 
     # add formatter
     corva_formatter = logging.Formatter(
-        '%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
-        '%(asset_id)s %(app_connection_id)s| %(message)s\n',
+        f'%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
+        f'%(asset_id)s {"" if app_connection_id is None else "%(app_connection_id)s "}'
+        f'| %(message)s\n',
         '%Y-%m-%dT%H:%M:%S',
     )
     corva_handler.setFormatter(corva_formatter)
@@ -58,9 +59,7 @@ class CorvaLoggerFilter(logging.Filter):
 
         self.aws_request_id = aws_request_id
         self.asset_id = f'ASSET={asset_id}'
-        self.app_connection_id = (
-            '' if app_connection_id is None else f'AC={app_connection_id} '
-        )
+        self.app_connection_id = f'AC={app_connection_id}'
 
     def filter(self, record):
         record.aws_request_id = self.aws_request_id

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -28,7 +28,8 @@ def setup_logging(aws_request_id: str, asset_id: int, app_connection_id: Optiona
     # add formatter
     corva_formatter = logging.Formatter(
         f'%(asctime)s.%(msecs)03dZ %(aws_request_id)s %(levelname)s '
-        f'%(asset_id)s {"" if app_connection_id is None else "%(app_connection_id)s "}'
+        f'ASSET=%(asset_id)s '
+        f'{"" if app_connection_id is None else "AC=%(app_connection_id)s "}'
         f'| %(message)s\n',
         '%Y-%m-%dT%H:%M:%S',
     )
@@ -58,8 +59,8 @@ class CorvaLoggerFilter(logging.Filter):
         logging.Filter.__init__(self)
 
         self.aws_request_id = aws_request_id
-        self.asset_id = f'ASSET={asset_id}'
-        self.app_connection_id = f'AC={app_connection_id}'
+        self.asset_id = asset_id
+        self.app_connection_id = app_connection_id
 
     def filter(self, record):
         record.aws_request_id = self.aws_request_id

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -104,7 +104,7 @@ class CorvaLoggerHandler(logging.Handler):
             sys.stdout.write(msg)
             return
 
-        msg = f'{msg[: len(msg) - (self.logged_chars - self.max_chars - 1)]}\n'
+        msg = f'{msg[: len(msg) - (self.logged_chars - self.max_chars) - 1]}\n'
         sys.stdout.write(msg)
 
         self.warning_logged = True

--- a/src/corva/models/base.py
+++ b/src/corva/models/base.py
@@ -46,6 +46,7 @@ class BaseContext(pydantic.generics.GenericModel, Generic[RawBaseEventTV]):
     event: RawBaseEventTV
     settings: Settings
     api: Api
+    aws_request_id: str
     cache_: Optional[RedisState] = None
     cache_settings: dict = {}
 

--- a/src/corva/runners/scheduled.py
+++ b/src/corva/runners/scheduled.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable
 
 from corva.api import Api
+from corva.logger import setup_logging
 from corva.models.scheduled import ScheduledContext, ScheduledEvent
 
 
@@ -13,7 +14,12 @@ def set_schedule_as_completed(api: Api, schedule_id: int) -> None:
 def scheduled_runner(fn: Callable, context: ScheduledContext) -> Any:
     event = ScheduledEvent.parse_obj(context.event)
 
-    result = fn(event, context.api, context.cache)
+    with setup_logging(
+        aws_request_id=context.aws_request_id,
+        asset_id=context.event.asset_id,
+        app_connection_id=context.event.app_connection_id,
+    ):
+        result = fn(event, context.api, context.cache)
 
     # should never raise
     set_schedule_as_completed(api=context.api, schedule_id=context.event.schedule_id)

--- a/src/corva/runners/stream.py
+++ b/src/corva/runners/stream.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Union
 
+from corva.logger import setup_logging
 from corva.models.stream.context import StreamDepthContext, StreamTimeContext
 from corva.models.stream.raw import RawStreamEvent
 
@@ -19,7 +20,12 @@ def stream_runner(
         context.event.copy(update={'records': records}, deep=True)
     )
 
-    result = fn(event, context.api, context.cache)
+    with setup_logging(
+        aws_request_id=context.aws_request_id,
+        asset_id=context.event.asset_id,
+        app_connection_id=context.event.app_connection_id,
+    ):
+        result = fn(event, context.api, context.cache)
 
     context.set_last_value()
 

--- a/src/corva/runners/task.py
+++ b/src/corva/runners/task.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 import requests
 
 from corva.api import Api
+from corva.logger import setup_logging
 from corva.models.task import TaskContext, TaskEvent
 
 
@@ -31,7 +32,12 @@ def task_runner(fn: Callable, context: TaskContext) -> Any:
     try:
         task_event = get_task_event(api=context.api, task_id=context.event.task_id)
 
-        result = fn(task_event, context.api)
+        with setup_logging(
+            aws_request_id=context.aws_request_id,
+            asset_id=task_event.asset_id,
+            app_connection_id=None,
+        ):
+            result = fn(task_event, context.api)
     except Exception as exc:
         update_task_data(
             api=context.api,

--- a/src/corva/state/redis_adapter.py
+++ b/src/corva/state/redis_adapter.py
@@ -1,10 +1,7 @@
 from datetime import timedelta
-from logging import Logger, LoggerAdapter
-from typing import Optional, List, Dict, Union
+from typing import Dict, List, Optional, Union
 
-from redis import Redis, from_url, ConnectionError
-
-from corva.logger import DEFAULT_LOGGER
+from redis import ConnectionError, Redis, from_url
 
 REDIS_STORED_VALUE_TYPE = Union[bytes, str, int, float]
 
@@ -19,28 +16,30 @@ class RedisAdapter(Redis):
     DEFAULT_EXPIRY: timedelta = timedelta(days=60)
 
     def __init__(
-         self,
-         default_name: str,
-         cache_url: str,
-         logger: Union[Logger, LoggerAdapter] = DEFAULT_LOGGER,
-         **kwargs
+        self,
+        default_name: str,
+        cache_url: str,
+        **kwargs,
     ):
         kwargs.setdefault('decode_responses', True)
-        super().__init__(connection_pool=from_url(url=cache_url, **kwargs).connection_pool)
-        self.logger = logger
+        super().__init__(
+            connection_pool=from_url(url=cache_url, **kwargs).connection_pool
+        )
         self.default_name = default_name
         try:
             self.ping()
         except ConnectionError as exc:
-            raise ConnectionError(f'Could not connect to Redis with URL: {cache_url}') from exc
+            raise ConnectionError(
+                f'Could not connect to Redis with URL: {cache_url}'
+            ) from exc
 
     def hset(
-         self,
-         name: Optional[str] = None,
-         key: Optional[str] = None,
-         value: Optional[REDIS_STORED_VALUE_TYPE] = None,
-         mapping: Optional[Dict[str, REDIS_STORED_VALUE_TYPE]] = None,
-         expiry: Union[int, timedelta, None] = DEFAULT_EXPIRY
+        self,
+        name: Optional[str] = None,
+        key: Optional[str] = None,
+        value: Optional[REDIS_STORED_VALUE_TYPE] = None,
+        mapping: Optional[Dict[str, REDIS_STORED_VALUE_TYPE]] = None,
+        expiry: Union[int, timedelta, None] = DEFAULT_EXPIRY,
     ) -> int:
         """Stores the data in cache
 
@@ -66,7 +65,9 @@ class RedisAdapter(Redis):
 
         return n_set
 
-    def hget(self, key: str, name: Optional[str] = None) -> Union[REDIS_STORED_VALUE_TYPE, None]:
+    def hget(
+        self, key: str, name: Optional[str] = None
+    ) -> Union[REDIS_STORED_VALUE_TYPE, None]:
         """Loads data from cache
 
         params:
@@ -77,7 +78,9 @@ class RedisAdapter(Redis):
         name = name or self.default_name
         return super().hget(name=name, key=key)
 
-    def hgetall(self, name: Optional[str] = None) -> Dict[str, Union[REDIS_STORED_VALUE_TYPE]]:
+    def hgetall(
+        self, name: Optional[str] = None
+    ) -> Dict[str, Union[REDIS_STORED_VALUE_TYPE]]:
         """Loads all data from cache"""
 
         name = name or self.default_name

--- a/src/corva/state/redis_state.py
+++ b/src/corva/state/redis_state.py
@@ -1,8 +1,6 @@
-from logging import Logger, LoggerAdapter
-from typing import Optional, Union
+from typing import Optional
 
 from corva.configuration import Settings
-from corva.logger import DEFAULT_LOGGER
 from corva.state.redis_adapter import RedisAdapter
 
 
@@ -14,11 +12,8 @@ class RedisState:
     This class provides and interface to save, load and do other operations with data in redis.
     """
 
-    def __init__(
-        self, redis: RedisAdapter, logger: Union[Logger, LoggerAdapter] = DEFAULT_LOGGER
-    ):
+    def __init__(self, redis: RedisAdapter):
         self.redis = redis
-        self.logger = logger
 
     def store(self, **kwargs):
         return self.redis.hset(**kwargs)

--- a/src/corva/testing.py
+++ b/src/corva/testing.py
@@ -20,7 +20,8 @@ class TestClient:
     """
 
     _context: ClassVar[types.SimpleNamespace] = types.SimpleNamespace(
-        client_context=types.SimpleNamespace(env={'API_KEY': '123'})
+        aws_request_id='qwerty',
+        client_context=types.SimpleNamespace(env={'API_KEY': '123'}),
     )
     _api: ClassVar[Api] = get_api(context=_context, settings=SETTINGS)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,230 @@
+import datetime
+
+import freezegun
+import pytest
+from pytest_mock import MockerFixture
+
+from corva import Corva, Logger
+from corva.configuration import SETTINGS
+from corva.models.scheduled import RawScheduledEvent
+from corva.models.stream.log_type import LogType
+from corva.models.stream.raw import (
+    RawAppMetadata,
+    RawMetadata,
+    RawStreamEvent,
+    RawStreamTimeEvent,
+    RawTimeRecord,
+)
+from corva.models.task import RawTaskEvent, TaskEvent
+
+
+def test_scheduled_logging(context, capsys, mocker: MockerFixture):
+    def app(event, api, cache):
+        Logger.warning('Hello, World!')
+
+    event = RawScheduledEvent(
+        asset_id=0,
+        interval=int(),
+        schedule=int(),
+        schedule_start=int(),
+        app_connection=1,
+        app_stream=int(),
+    )
+
+    mocker.patch('corva.runners.scheduled.set_schedule_as_completed')
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).scheduled(
+            app,
+            [
+                [
+                    event.dict(
+                        by_alias=True,
+                        exclude_unset=True,
+                    )
+                ]
+            ],
+        )
+
+    assert (
+        capsys.readouterr().out
+        == f'2021-01-02T03:04:05.678Z {context.aws_request_id} WARNING '
+        f'ASSET={event.asset_id} AC={event.app_connection_id} | Hello, World!\n'
+    )
+
+
+def test_stream_logging(context, capsys):
+    def app(event, api, cache):
+        Logger.warning('Hello, World!')
+
+    event = RawStreamTimeEvent(
+        records=[
+            RawTimeRecord(
+                asset_id=0,
+                company_id=int(),
+                collection=str(),
+                timestamp=int(),
+            ),
+        ],
+        metadata=RawMetadata(
+            app_stream_id=int(),
+            apps={SETTINGS.APP_KEY: RawAppMetadata(app_connection_id=1)},
+            log_type=LogType.time,
+        ),
+    )
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).stream(
+            app,
+            [event.dict()],
+        )
+
+    assert (
+        capsys.readouterr().out
+        == f'2021-01-02T03:04:05.678Z {context.aws_request_id} WARNING '
+        f'ASSET={event.asset_id} AC={event.app_connection_id} | Hello, World!\n'
+    )
+
+
+def test_task_logging(context, capsys, mocker: MockerFixture):
+    def app(event, api):
+        Logger.warning('Hello, World!')
+
+    raw_event = RawTaskEvent(task_id='0', version=2).dict()
+    event = TaskEvent(asset_id=0, company_id=int())
+
+    mocker.patch(
+        'corva.runners.task.get_task_event',
+        return_value=TaskEvent(asset_id=0, company_id=int()),
+    )
+    mocker.patch('corva.runners.task.update_task_data')
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).task(fn=app, event=raw_event)
+
+    captured = capsys.readouterr()
+
+    assert (
+        captured.out == f'2021-01-02T03:04:05.678Z {context.aws_request_id} WARNING '
+        f'ASSET={event.asset_id}  | Hello, World!\n'
+    )
+
+
+def test_max_chars_reached(context, capsys, mocker: MockerFixture):
+    def app(event, api, cache):
+        Logger.warning('Hello, World!')
+        Logger.warning('This should not be printed as logging is disabled.')
+
+    event = RawStreamTimeEvent(
+        records=[
+            RawTimeRecord(
+                asset_id=0,
+                company_id=int(),
+                collection=str(),
+                timestamp=int(),
+            ),
+        ],
+        metadata=RawMetadata(
+            app_stream_id=int(),
+            apps={SETTINGS.APP_KEY: RawAppMetadata(app_connection_id=1)},
+            log_type=LogType.time,
+        ),
+    )
+
+    mocker.patch.object(SETTINGS, 'LOG_MAX_CHARS', 68)
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).stream(
+            app,
+            [event.dict()],
+        )
+
+    # exclamation point was cut from the message
+    expected = (
+        '2021-01-02T03:04:05.678Z qwerty WARNING ASSET=0 AC=1 | Hello, World\n'
+        '2021-01-02T03:04:05.678Z qwerty WARNING ASSET=0 AC=1 | Disabling the '
+        'logging as maximum number of logged characters was reached: 68.\n'
+    )
+
+    assert capsys.readouterr().out == expected
+
+
+@pytest.mark.parametrize(
+    'log_level,expected',
+    (
+        ['WARN', ''],
+        ['INFO', '2021-01-02T03:04:05.678Z qwerty INFO ASSET=0 AC=1 | Info message.\n'],
+    ),
+)
+def test_custom_log_level(log_level, expected, context, capsys, mocker: MockerFixture):
+    def app(event, api, cache):
+        Logger.debug('Debug message.')
+        Logger.info('Info message.')
+
+    event = RawStreamTimeEvent(
+        records=[
+            RawTimeRecord(
+                asset_id=0,
+                company_id=int(),
+                collection=str(),
+                timestamp=int(),
+            ),
+        ],
+        metadata=RawMetadata(
+            app_stream_id=int(),
+            apps={SETTINGS.APP_KEY: RawAppMetadata(app_connection_id=1)},
+            log_type=LogType.time,
+        ),
+    )
+
+    mocker.patch.object(SETTINGS, 'LOG_LEVEL', log_level)
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).stream(
+            app,
+            [event.dict()],
+        )
+
+    assert capsys.readouterr().out == expected
+
+
+def test_each_app_invoke_has_separate_logger(context, capsys, mocker: MockerFixture):
+    def app(event, api, cache):
+        Logger.warning(f'Hello, World!')
+        Logger.warning('This should not be printed as logging is disabled.')
+
+    event = RawStreamTimeEvent(
+        records=[
+            RawTimeRecord(
+                asset_id=0,
+                company_id=int(),
+                collection=str(),
+                timestamp=int(),
+            ),
+        ],
+        metadata=RawMetadata(
+            app_stream_id=int(),
+            apps={SETTINGS.APP_KEY: RawAppMetadata(app_connection_id=1)},
+            log_type=LogType.time,
+        ),
+    )
+
+    # disable filtering, as app won't be invoked the second time
+    mocker.patch.object(RawStreamEvent, 'filter_records', return_value=event.records)
+    # first app invoke will reach the limit.
+    # so, if logger is shared, second invoke will log nothing.
+    mocker.patch.object(SETTINGS, 'LOG_MAX_CHARS', 68)
+
+    with freezegun.freeze_time(datetime.datetime(2021, 1, 2, 3, 4, 5, 678910)):
+        Corva(context).stream(
+            app,
+            [event.dict()] * 2,
+        )
+
+    expected = (
+        '2021-01-02T03:04:05.678Z qwerty WARNING ASSET=0 AC=1 | Hello, World\n'
+        '2021-01-02T03:04:05.678Z qwerty WARNING ASSET=0 AC=1 | Disabling the '
+        'logging as maximum number of logged characters was reached: 68.\n'
+    ) * 2
+
+    assert capsys.readouterr().out == expected

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -106,7 +106,7 @@ def test_task_logging(context, capsys, mocker: MockerFixture):
 
     assert (
         captured.out == f'2021-01-02T03:04:05.678Z {context.aws_request_id} WARNING '
-        f'ASSET={event.asset_id}  | Hello, World!\n'
+        f'ASSET={event.asset_id} | Hello, World!\n'
     )
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -190,7 +190,7 @@ def test_custom_log_level(log_level, expected, context, capsys, mocker: MockerFi
 
 def test_each_app_invoke_has_separate_logger(context, capsys, mocker: MockerFixture):
     def app(event, api, cache):
-        Logger.warning(f'Hello, World!')
+        Logger.warning('Hello, World!')
         Logger.warning('This should not be printed as logging is disabled.')
 
     event = RawStreamTimeEvent(


### PR DESCRIPTION
Rationale.
Users need a safe way to do logging in apps. Safe means - apps should not be able to log too much, as this will incur huge expenses for users.

[DC-1039 Implement logging thresholds](https://corvaqa.atlassian.net/browse/DC-1039)
[DC-1073 Prefix log messages with Asset ID and App Connection ID](https://corvaqa.atlassian.net/browse/DC-1073)

- Added logger to SDK
- Added `LOG_THRESHOLD_MESSAGE_SIZE` and `LOG_THRESHOLD_MESSAGE_COUNT` env variables, that limit logging
- Deleted logger usage from state/ dir