### PR TITLE
Allow events have extra fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Events are allowed to have extra fields.
 
 ## [0.0.17] - 2021-04-15
 

--- a/src/corva/models/base.py
+++ b/src/corva/models/base.py
@@ -11,7 +11,7 @@ from corva.state.redis_state import RedisState, get_cache
 
 
 class EventConfig:
-    extra = pydantic.Extra.ignore
+    extra = pydantic.Extra.allow
     allow_mutation = False
 
 


### PR DESCRIPTION
### Rationale
User app events may contain extra fields unique to that app. Currently SDK ignores such fields. Allow events to have extra fields and let users be responsible for managing them.

### Changes
Events are allowed to have extra fields.


[https://corvaqa.atlassian.net/browse/DC-1483](put the link to the corresponding JIRA ticket here)

#### TODO
- [*] Update CHANGELOG.md
