### PR TITLE
Feature/dc 1520 add company id to scheduled event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `corva.stream`, `corva.scheduled` and `corva.task` app decorators. 
   See readme for usage examples.
+- `ScheduledEvent.company_id` field.  
 
 ### Removed
 - `corva.Corva` class.

--- a/src/corva/models/scheduled.py
+++ b/src/corva/models/scheduled.py
@@ -24,11 +24,13 @@ class ScheduledEvent(CorvaBaseEvent):
 
     Attributes:
         asset_id: asset id.
+        company_id: company id.
         start_time: left bound of the time range, covered by this event. Use inclusively.
         end_time: right bound of the time range, covered by this event. Use inclusively.
     """
 
     asset_id: int
+    company_id: int
     start_time: int
     end_time: int = pydantic.Field(..., alias='schedule_start')
 
@@ -38,6 +40,7 @@ class ScheduledEvent(CorvaBaseEvent):
 
 class RawScheduledEvent(CorvaBaseEvent, RawBaseEvent):
     asset_id: int
+    company_id: int
     interval: int = pydantic.Field(
         ..., description='Time in seconds between two schedule triggers'
     )

--- a/src/corva/models/scheduled.py
+++ b/src/corva/models/scheduled.py
@@ -40,7 +40,7 @@ class ScheduledEvent(CorvaBaseEvent):
 
 class RawScheduledEvent(CorvaBaseEvent, RawBaseEvent):
     asset_id: int
-    company_id: int
+    company_id: int = pydantic.Field(..., alias='company')
     interval: int = pydantic.Field(
         ..., description='Time in seconds between two schedule triggers'
     )

--- a/src/corva/models/stream/log_type.py
+++ b/src/corva/models/stream/log_type.py
@@ -7,19 +7,9 @@ class LogType(enum.Enum):
 
     @property
     def raw_event(self):
-        from corva.models.stream.raw import (
-            RawStreamDepthEvent,
-            RawStreamTimeEvent,
-        )
+        from corva.models.stream.raw import RawStreamDepthEvent, RawStreamTimeEvent
 
         mapping = {self.time: RawStreamTimeEvent, self.depth: RawStreamDepthEvent}
-        return mapping[self]
-
-    @property
-    def context(self):
-        from corva.models.stream.context import StreamDepthContext, StreamTimeContext
-
-        mapping = {self.time: StreamTimeContext, self.depth: StreamDepthContext}
         return mapping[self]
 
     @property

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,7 +31,7 @@ def test_scheduled_logging(context, capsys, mocker: MockerFixture):
         schedule_start=int(),
         app_connection=1,
         app_stream=int(),
-        company_id=int(),
+        company=int(),
     )
 
     mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,6 +31,7 @@ def test_scheduled_logging(context, capsys, mocker: MockerFixture):
         schedule_start=int(),
         app_connection=1,
         app_stream=int(),
+        company_id=int(),
     )
 
     mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -30,7 +30,9 @@ def test_scheduled_app_runner(app_runner):
     def scheduled_app(event, api, cache):
         return 'Scheduled app result'
 
-    event = ScheduledEvent(asset_id=int(), start_time=int(), end_time=int())
+    event = ScheduledEvent(
+        asset_id=int(), start_time=int(), end_time=int(), company_id=int()
+    )
 
     assert app_runner(scheduled_app, event) == 'Scheduled app result'
 

--- a/tests/test_scheduled_app.py
+++ b/tests/test_scheduled_app.py
@@ -21,7 +21,7 @@ def test_set_completed_status(context, requests_mock):
                 schedule_start=int(),
                 app_connection=int(),
                 app_stream=int(),
-                company_id=int(),
+                company=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,
@@ -72,7 +72,7 @@ def test_set_schedule_start(value, expected, context, mocker: MockerFixture):
                 schedule_start=value,
                 app_connection=int(),
                 app_stream=int(),
-                company_id=int(),
+                company=int(),
             ).dict(by_alias=True, exclude_unset=True, exclude_defaults=True)
         ]
     ]
@@ -107,7 +107,7 @@ def test_set_start_time(
                 schedule_start=schedule_start,
                 app_connection=int(),
                 app_stream=int(),
-                company_id=int(),
+                company=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,
@@ -136,7 +136,7 @@ def test_set_completed_status_should_not_fail_lambda(context, mocker: MockerFixt
                 schedule_start=int(),
                 app_connection=int(),
                 app_stream=int(),
-                company_id=int(),
+                company=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,

--- a/tests/test_scheduled_app.py
+++ b/tests/test_scheduled_app.py
@@ -21,6 +21,7 @@ def test_set_completed_status(context, requests_mock):
                 schedule_start=int(),
                 app_connection=int(),
                 app_stream=int(),
+                company_id=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,
@@ -71,6 +72,7 @@ def test_set_schedule_start(value, expected, context, mocker: MockerFixture):
                 schedule_start=value,
                 app_connection=int(),
                 app_stream=int(),
+                company_id=int(),
             ).dict(by_alias=True, exclude_unset=True, exclude_defaults=True)
         ]
     ]
@@ -105,6 +107,7 @@ def test_set_start_time(
                 schedule_start=schedule_start,
                 app_connection=int(),
                 app_stream=int(),
+                company_id=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,
@@ -133,6 +136,7 @@ def test_set_completed_status_should_not_fail_lambda(context, mocker: MockerFixt
                 schedule_start=int(),
                 app_connection=int(),
                 app_stream=int(),
+                company_id=int(),
             ).dict(
                 by_alias=True,
                 exclude_unset=True,


### PR DESCRIPTION
### Rationale
`StreamEvent` and `TaskEvent` have `company_id` field. We want to add this field to `ScheduledEvent` also for consistency.

### Changes
* Added `company_id` field to `ScheduledEvent`
* Deleted unused `LogType.context` property

[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-1520)

#### TODO
- [x] Update CHANGELOG.md
