### PR TITLE
Fixed aws context parsing

### DIFF
--- a/src/corva/handlers.py
+++ b/src/corva/handlers.py
@@ -18,7 +18,9 @@ def base_handler(raw_event_type: Type[RawBaseEvent]) -> Callable:
     def decorator(func: Callable[[RawBaseEvent, Api, str], Any]) -> Callable:
         @functools.wraps(func)
         def wrapper(aws_event: Any, aws_context: Any) -> List[Any]:
-            context = CorvaContext.parse_obj(aws_context)
+            context = CorvaContext.from_aws(
+                aws_event=aws_event, aws_context=aws_context
+            )
 
             api = Api(
                 api_url=SETTINGS.API_ROOT_URL,

--- a/src/corva/models/context.py
+++ b/src/corva/models/context.py
@@ -1,15 +1,47 @@
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+from unittest import mock
+
 import pydantic
+
+
+class AwsEventWithClientContext(pydantic.BaseModel):
+    client_context: dict
+
+
+class ClientContext(pydantic.BaseModel):
+    class Config:
+        orm_mode = True
+
+    env: pydantic.create_model('Env', API_KEY=(str, ...))  # noqa: F821
 
 
 class CorvaContext(pydantic.BaseModel):
     """AWS context, expected by Corva."""
 
+    class Config:
+        orm_mode = True
+
     aws_request_id: str
-    client_context: pydantic.create_model(
-        "ClientContext",  # noqa: F821
-        env=(pydantic.create_model("Env", API_KEY=(str, ...)), ...),  # noqa: F821
-    )
+    client_context: ClientContext
 
     @property
     def api_key(self) -> str:
         return self.client_context.env.API_KEY
+
+    @classmethod
+    def from_aws(cls, aws_event: Any, aws_context: Any) -> CorvaContext:
+        parse_ctx = (
+            mock.patch.object(
+                aws_context,
+                'client_context',
+                AwsEventWithClientContext.parse_obj(aws_event).client_context,
+            )
+            if aws_context.client_context is None
+            else contextlib.nullcontext()
+        )
+
+        with parse_ctx:
+            return CorvaContext.from_orm(aws_context)

--- a/src/corva/testing.py
+++ b/src/corva/testing.py
@@ -1,9 +1,9 @@
 import inspect
+from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Union
 
 from corva.api import Api
 from corva.configuration import SETTINGS
-from corva.models.context import CorvaContext
 from corva.models.scheduled import ScheduledEvent
 from corva.models.stream.stream import StreamEvent
 from corva.models.task import TaskEvent
@@ -18,13 +18,13 @@ class TestClient:
         _api: Api instance.
     """
 
-    _context: ClassVar[CorvaContext] = CorvaContext(
-        aws_request_id='qwerty', client_context={'env': {'API_KEY': '123'}}
+    _context: ClassVar[SimpleNamespace] = SimpleNamespace(
+        aws_request_id='qwerty', client_context=SimpleNamespace(env={'API_KEY': '123'})
     )
     _api: ClassVar[Api] = Api(
         api_url=SETTINGS.API_ROOT_URL,
         data_api_url=SETTINGS.DATA_API_ROOT_URL,
-        api_key=_context.api_key,
+        api_key=_context.client_context.env['API_KEY'],
         app_key=SETTINGS.APP_KEY,
     )
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,71 @@
+import contextlib
+from types import SimpleNamespace
+
+import pydantic
+import pytest
+import requests_mock as requests_mock_lib
+from requests_mock import Mocker as RequestsMocker
+
+from corva.handlers import task
+from corva.models.task import RawTaskEvent, TaskEvent
+
+
+@task
+def task_app(event, api):
+    return api.api_key
+
+
+@pytest.mark.parametrize(
+    'aws_event,aws_context,exc_ctx,expected',
+    (
+        [
+            RawTaskEvent(task_id='', version=2).dict(),
+            SimpleNamespace(
+                aws_request_id='', client_context=SimpleNamespace(env={'API_KEY': ''})
+            ),
+            contextlib.nullcontext(),
+            '',
+        ],
+        [
+            RawTaskEvent(
+                task_id='', version=2, client_context={'env': {'API_KEY': ''}}
+            ).dict(),
+            SimpleNamespace(aws_request_id='', client_context=None),
+            contextlib.nullcontext(),
+            '',
+        ],
+        [
+            RawTaskEvent(
+                task_id='', version=2, client_context={'env': {'API_KEY': '0'}}
+            ).dict(),
+            SimpleNamespace(
+                aws_request_id='', client_context=SimpleNamespace(env={'API_KEY': '1'})
+            ),
+            contextlib.nullcontext(),
+            '1',
+        ],
+        [
+            RawTaskEvent(task_id='', version=2).dict(),
+            SimpleNamespace(aws_request_id='', client_context=None),
+            pytest.raises(pydantic.ValidationError),
+            '',
+        ],
+    ),
+    ids=(
+        'Lambda context has not None `client_context`. Lambda event has no `client_context`.',
+        'Lambda context has None `client_context`. Lambda event has `client_context`.',
+        'Lambda context has not None `client_context`. Lambda event has `client_context`.',
+        'No `client_context` in Lambda context and event.',
+    ),
+)
+def test_context(
+    aws_event, aws_context, exc_ctx, expected, requests_mock: RequestsMocker
+):
+    requests_mock.request(
+        requests_mock_lib.ANY,
+        requests_mock_lib.ANY,
+        json=TaskEvent(asset_id=0, company_id=0).dict(),
+    )
+
+    with exc_ctx:
+        assert task_app(aws_event, aws_context)[0] == expected


### PR DESCRIPTION
### Rationale
We want to look for `client_context` in aws event if aws context doesnt have one.

### Changes
* Look for `client_context` in aws event if aws context doesnt have one.
* Fixed aws context parsing.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-1542)

#### TODO
- [ ] Update CHANGELOG.md
