### PR TITLE
Fix/dc 1806 delete obsolete logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Multiple logging of the same exception in stream and scheduled apps.
+
 
 ## [1.0.3] - 2021-06-27
 

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -122,6 +122,22 @@ class CorvaLoggerHandler(logging.Handler):
 
 
 class LoggingContext(contextlib.ContextDecorator):
+    """Context manager to configure logger to use specified handler.
+
+    Hanlder is configured to use CorvaLoggerFilter and log level from settings.
+
+    Context allows setting some filter's fields dynamically. It will update logging
+    formatter as needed.
+
+    Logger gets its old handlers back at the end of the context.
+
+    Attributes:
+        filter: Logging filter that gets set in the handler.
+        handler: Logging handler that gets set in the logger.
+        logger: Logger to configure.
+        old_handlers: Logger's own handlers before the update.
+    """
+
     def __init__(
         self,
         aws_request_id: str,
@@ -147,6 +163,8 @@ class LoggingContext(contextlib.ContextDecorator):
 
     @property
     def asset_id(self) -> Optional[int]:
+        """Asset id used in the logging filter."""
+
         return self.filter.asset_id
 
     @asset_id.setter
@@ -156,6 +174,8 @@ class LoggingContext(contextlib.ContextDecorator):
 
     @property
     def app_connection_id(self) -> Optional[int]:
+        """App connection id used in the logging filter."""
+
         return self.filter.app_connection_id
 
     @app_connection_id.setter

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -3,7 +3,6 @@ import logging
 import logging.config
 import sys
 import time
-import traceback
 from typing import Optional
 
 from corva.configuration import SETTINGS
@@ -199,12 +198,6 @@ class LoggingContext(contextlib.ContextDecorator):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            err_msg = "".join(
-                traceback.TracebackException.from_exception(exc_val).format()
-            )
-            self.logger.error(f'An exception occured: {err_msg}')
-
         self.logger.handlers = self.old_handlers
 
         return False  # exception will be propagated

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -289,4 +289,4 @@ def test_lambda_exceptions_are_logged(context, capsys, mocker: MockerFixture):
 
     captured = capsys.readouterr()
 
-    assert 'An exception occured: ' in captured.out
+    assert 'The app failed to execute.' in captured.out

--- a/tests/test_scheduled_app.py
+++ b/tests/test_scheduled_app.py
@@ -184,5 +184,5 @@ def test_log_if_unable_to_set_completed_status(context, mocker: MockerFixture, c
     captured = capsys.readouterr()
 
     assert 'ASSET=0 AC=0' in captured.out
-    assert 'An exception occured while setting schedule as completed.' in captured.out
+    assert 'Could not set schedule as completed.' in captured.out
     patch.assert_called_once()

--- a/tests/test_stream_app.py
+++ b/tests/test_stream_app.py
@@ -509,5 +509,5 @@ def test_log_if_unable_to_set_cached_max_record_value(
     captured = capsys.readouterr()
 
     assert 'ASSET=0 AC=0' in captured.out
-    assert 'An exception occured while saving data to cache.' in captured.out
+    assert 'Could not save data to cache.' in captured.out
     patch.assert_called_once()

--- a/tests/test_task_app.py
+++ b/tests/test_task_app.py
@@ -156,7 +156,7 @@ def test_log_if_unable_to_update_task_data(context, mocker: MockerFixture, capsy
     captured = capsys.readouterr()
 
     assert 'ASSET=0' in captured.out
-    assert 'An exception occured while updating task data.' in captured.out
+    assert 'Could not update task data.' in captured.out
     update_task_data_patch.assert_called_once()
 
 
@@ -181,4 +181,4 @@ def test_log_if_user_app_fails(
 
     assert put_mock.called_once
     assert 'ASSET=0' in captured.out
-    assert 'An exception occured while running task app.' in captured.out
+    assert 'Task app failed to execute.' in captured.out


### PR DESCRIPTION
### Rationale
There is an issue of the same exception being logged two times in stream and scheduled apps.

### Changes
Moved logging of exceptions out of `LoggingContext.__exit__` method to have better control.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-1806)

#### TODO
- [ ] Update CHANGELOG.md
