### PR TITLE
Feature/dc 1781 allow custom logging handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Ability to pass custom logging handlers
+to app decorators using `handler` keyword argument.
+
 ### Fixed
 - Multiple logging of the same exception in stream and scheduled apps.
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -306,7 +306,8 @@ include::src/logging/tutorial001.py[]
 
 === Customizations
 You might want to send logs to other places
-(e.g., to error reporting systems like `Setry` or `Rollbar`).
+(e.g., to error reporting systems like
+<<sentry, `Sentry`>> or <<rollbar, `Rollbar`>>).
 This can be achieved by providing an instance of
 {python-log-handlers-link}[logging handler]
 as an argument to app decorator.
@@ -322,6 +323,79 @@ that we want to use.
 <.> Pass the handler as a keyword argument to the app decorator.
 <.> Logs will be sent to both `stream_handler`
 and {corva-sdk}'s default one.
+
+=== Error logging systems
+
+[#sentry]
+==== Sentry
+
+https://docs.sentry.io/platforms/python/[
+Sentry for Python documentation.
+]
+
+[source,bash]
+----
+pip install sentry-sdk <.>
+----
+<.> Install the library.
+
+[source,python]
+----
+include::src/logging/tutorial003.py[]
+----
+<.> Import Sentry SDK.
+<.> Initialize the library.
+<.> All errors will be reported to Sentry now.
+
+[#rollbar]
+==== Rollbar
+
+https://docs.rollbar.com/docs/python[
+Rollbar for Python documentation.
+]
+
+[source,bash]
+----
+pip install rollbar <.>
+----
+<.> Install the library.
+
+[source,python]
+----
+include::src/logging/tutorial004.py[]
+----
+<.> Import Rollbar SDK.
+<.> Initialize Rollbar handler.
+<.> Pass the handler as a keyword argument to the app decorator.
+<.> All errors will be reported to Rollbar now.
+
+==== Raygun
+https://raygun.com/documentation/language-guides/python/crash-reporting/installation/[
+Raygun for Python documentation.
+]
+
+[source,bash]
+----
+pip install raygun4py <.>
+----
+<.> Install the library.
+
+[source,python]
+----
+include::src/logging/tutorial005.py[]
+----
+<.> Import Raygun SDK.
+<.> Initialize Raygun handler.
+<.> Pass the handler as a keyword argument to the app decorator.
+<.> All errors will be reported to Raygun now.
+
+==== Other libraries
+You can use any other error logging libraries.
+Just initialize
+and pass corresponding logging handler
+as a keyword argument to the app decorator.
+Use code samples above as the examples.
+
 
 == Testing
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -324,8 +324,6 @@ that we want to use.
 <.> Logs will be sent to both `stream_handler`
 and {corva-sdk}'s default one.
 
-=== Error logging systems
-
 [#sentry]
 ==== Sentry
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -12,6 +12,7 @@
 :corva-data-api-link: https://data.corva.ai/docs#/[Corva Data API]
 :api-v1-data-provider-dataset-link: https://data.corva.ai/docs#/default/index_api_v1_data__provider___dataset___get[/api/v1/data/provider/dataset/]
 :python-log-levels-link: https://docs.python.org/3/howto/logging.html[Python log levels]
+:python-log-handlers-link: https://docs.python.org/3/howto/logging.html#handlers
 :pytest-plugin-link: https://docs.pytest.org/en/stable/writing_plugins.html[pytest-plugin]
 :corva-sdk: pass:quotes[*corva-sdk*]
 :app-step1: Import required functionality.
@@ -302,6 +303,25 @@ include::src/logging/tutorial001.py[]
 ----
 <.> Import `Logger` object.
 <.> Use `Logger` as every other Python logger.
+
+=== Customizations
+You might want to send logs to other places
+(e.g., to error reporting systems like `Setry` or `Rollbar`).
+This can be achieved by providing an instance of
+{python-log-handlers-link}[logging handler]
+as an argument to app decorator.
+Custom handler will be used alongside {corva-sdk}'s default one.
+
+[source,python]
+----
+include::src/logging/tutorial002.py[]
+----
+<.> Import the module which contains the handler
+that we want to use.
+<.> Initialize the handler.
+<.> Pass the handler as a keyword argument to the app decorator.
+<.> Logs will be sent to both `stream_handler`
+and {corva-sdk}'s default one.
 
 == Testing
 

--- a/docs/src/logging/tutorial002.py
+++ b/docs/src/logging/tutorial002.py
@@ -1,0 +1,10 @@
+import logging  # <.>
+
+from corva import Api, Logger, TaskEvent, task
+
+stream_handler = logging.StreamHandler()  # <.>
+
+
+@task(handler=stream_handler)  # <.>
+def task_app(event: TaskEvent, api: Api):
+    Logger.info('Info message!')  # <.>

--- a/docs/src/logging/tutorial003.py
+++ b/docs/src/logging/tutorial003.py
@@ -1,0 +1,9 @@
+import sentry_sdk  # <.>
+from corva import Api, TaskEvent, task, Logger
+
+sentry_sdk.init("YOUR_SENTRY_DSN")  # <.>
+
+
+@task
+def app(event: TaskEvent, api: Api) -> None:
+    1 / 0  # <.>

--- a/docs/src/logging/tutorial003.py
+++ b/docs/src/logging/tutorial003.py
@@ -1,5 +1,6 @@
 import sentry_sdk  # <.>
-from corva import Api, TaskEvent, task, Logger
+
+from corva import Api, TaskEvent, task
 
 sentry_sdk.init("YOUR_SENTRY_DSN")  # <.>
 

--- a/docs/src/logging/tutorial004.py
+++ b/docs/src/logging/tutorial004.py
@@ -1,0 +1,9 @@
+import rollbar.logger  # <.>
+from corva import Api, TaskEvent, task
+
+rollbar_handler = rollbar.logger.RollbarHandler('YOUR_ROLLBAR_ACCESS_TOKEN')  # <.>
+
+
+@task(handler=rollbar_handler)  # <.>
+def app(event: TaskEvent, api: Api) -> None:
+    1 / 0  # <.>

--- a/docs/src/logging/tutorial004.py
+++ b/docs/src/logging/tutorial004.py
@@ -1,4 +1,5 @@
 import rollbar.logger  # <.>
+
 from corva import Api, TaskEvent, task
 
 rollbar_handler = rollbar.logger.RollbarHandler('YOUR_ROLLBAR_ACCESS_TOKEN')  # <.>

--- a/docs/src/logging/tutorial005.py
+++ b/docs/src/logging/tutorial005.py
@@ -1,0 +1,9 @@
+import raygun4py.raygunprovider  # <.>
+from corva import Api, TaskEvent, task
+
+raygun_handler = raygun4py.raygunprovider.RaygunHandler('YOUR_RAYGUN_API_KEY')  # <.>
+
+
+@task(handler=raygun_handler)  # <.>
+def app(event: TaskEvent, api: Api) -> None:
+    1 / 0  # <.>

--- a/docs/src/logging/tutorial005.py
+++ b/docs/src/logging/tutorial005.py
@@ -1,4 +1,5 @@
 import raygun4py.raygunprovider  # <.>
+
 from corva import Api, TaskEvent, task
 
 raygun_handler = raygun4py.raygunprovider.RaygunHandler('YOUR_RAYGUN_API_KEY')  # <.>

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ branch = True
 
 [coverage:report]
 precision = 2
+fail_under = 98.709
 skip_covered = True
 show_missing = True
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ branch = True
 
 [coverage:report]
 precision = 2
-fail_under = 98.709
+fail_under = 97.51
 skip_covered = True
 show_missing = True
 exclude_lines =

--- a/tests/test_docs/test_logging.py
+++ b/tests/test_docs/test_logging.py
@@ -3,7 +3,8 @@ import logging
 from pytest_mock import MockerFixture
 
 from corva import Logger, TaskEvent
-from docs.src.logging import tutorial001
+from corva.models.task import RawTaskEvent
+from docs.src.logging import tutorial001, tutorial002
 
 
 def test_tutorial001(app_runner, mocker: MockerFixture, capsys):
@@ -26,3 +27,23 @@ def test_tutorial001(app_runner, mocker: MockerFixture, capsys):
     captured = capsys.readouterr().err
 
     assert captured.startswith(expected)
+
+
+def test_tutorial002(context, mocker: MockerFixture, capsys, caplog):
+    raw_event = RawTaskEvent(task_id='0', version=2).dict()
+    event = TaskEvent(asset_id=0, company_id=int())
+
+    mocker.patch.object(
+        RawTaskEvent,
+        'get_task_event',
+        return_value=event,
+    )
+    mocker.patch.object(RawTaskEvent, 'update_task_data')
+    mocker.patch.object(Logger, 'propagate', True)  # for caplog to work
+
+    tutorial002.task_app(raw_event, context)
+
+    captured = capsys.readouterr()
+
+    assert captured.out.endswith('Info message!\n')
+    assert caplog.messages == ['Info message!']


### PR DESCRIPTION
### Rationale
Users should be able to use custom logging handlers.

### Changes
Added ability to pass custom logging handlers to app decorators using `handler` keyword argument.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-1781)

#### TODO
- [x] Update CHANGELOG.md
