### PR TITLE
add authentication scheme argument to be possible to use bearer

### DIFF
--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -23,17 +23,19 @@ class Api:
         api_key: str,
         app_key: str,
         timeout: Optional[int] = None,
+        authentication_scheme: Optional[str] = 'API'
     ):
         self.api_url = api_url
         self.data_api_url = data_api_url
         self.api_key = api_key
         self.app_key = app_key
         self.timeout = timeout or self.TIMEOUT_LIMITS[1]
+        self.authentication_scheme = authentication_scheme
 
     @property
     def default_headers(self):
         return {
-            'Authorization': f'API {self.api_key}',
+            'Authorization': f'{self.authentication_scheme} {self.api_key}',
             'X-Corva-App': self.app_key,
         }
 


### PR DESCRIPTION
### Rationale
*Let us know why do you make a change*
This change could be important to give access to authenticate the API from Corva without a Api Key, I will be possible to use Bearer authentication scheme that is accessible to developers authenticated.

### Changes
*Describe what you changed*
I add a new argument at the constructor of Api to be possible to choice the authentication scheme that the developer would like to use. The argument will keep working for old version due to the default value for authentication_scheme


[JIRA ticket](put the link to the corresponding JIRA ticket here)

#### TODO
- [x] Update CHANGELOG.md
