### PR TITLE
DC-3321: Do not log internal SDK error using `exception` level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong log formatting in Dev Center:
 multiline Python logs (like stack traces)
 being split into multiple CloudWatch log entries.
-- Internal SDK errors being logged
-as `exception`
 
 ### Changed
 - Log internal SDK errors using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong log formatting in Dev Center:
 multiline Python logs (like stack traces)
 being split into multiple CloudWatch log entries.
+- Internal SDK errors being logged
+as `exception`
 
+### Changed
+- Log internal SDK errors using
+`warning` level instead of `exception`.
 
 ## [1.4.0-rc.1] - 2021-02-15
 

--- a/src/corva/handlers.py
+++ b/src/corva/handlers.py
@@ -151,9 +151,9 @@ def stream(
 
         try:
             event.set_cached_max_record_value(cache=user_cache_sdk)
-        except Exception:
+        except Exception as e:
             # lambda succeeds if we're unable to cache the value
-            CORVA_LOGGER.exception('Could not save data to cache.')
+            CORVA_LOGGER.warning(f'Could not save data to cache. Details: {str(e)}.')
 
         return result
 
@@ -226,9 +226,11 @@ def scheduled(
 
         try:
             event.set_schedule_as_completed(api=api)
-        except Exception:
+        except Exception as e:
             # lambda succeeds if we're unable to set completed status
-            CORVA_LOGGER.exception('Could not set schedule as completed.')
+            CORVA_LOGGER.warning(
+                f'Could not set schedule as completed. Details: {str(e)}.'
+            )
 
         return result
 
@@ -314,8 +316,8 @@ def task(
                     status=status,
                     data=data,
                 ).raise_for_status()
-            except Exception:
+            except Exception as e:
                 # lambda succeeds if we're unable to update task data
-                CORVA_LOGGER.exception('Could not update task data.')
+                CORVA_LOGGER.warning(f'Could not update task data. Details: {str(e)}.')
 
     return wrapper

--- a/tests/unit/test_scheduled_app.py
+++ b/tests/unit/test_scheduled_app.py
@@ -285,7 +285,7 @@ def test_log_if_unable_to_set_completed_status(context, mocker: MockerFixture, c
     ]
 
     patch = mocker.patch.object(
-        RawScheduledEvent, 'set_schedule_as_completed', side_effect=Exception
+        RawScheduledEvent, 'set_schedule_as_completed', side_effect=Exception('Oops!')
     )
 
     scheduled_app(event, context)
@@ -293,7 +293,7 @@ def test_log_if_unable_to_set_completed_status(context, mocker: MockerFixture, c
     captured = capsys.readouterr()
 
     assert 'ASSET=0 AC=0' in captured.out
-    assert 'Could not set schedule as completed.' in captured.out
+    assert 'Could not set schedule as completed. Details: Oops!.' in captured.out
     patch.assert_called_once()
 
 

--- a/tests/unit/test_stream_app.py
+++ b/tests/unit/test_stream_app.py
@@ -504,7 +504,7 @@ def test_log_if_unable_to_set_cached_max_record_value(
     ]
 
     patch = mocker.patch.object(
-        RawStreamEvent, 'set_cached_max_record_value', side_effect=Exception
+        RawStreamEvent, 'set_cached_max_record_value', side_effect=Exception('Oops!')
     )
 
     stream_app(event, context)
@@ -512,7 +512,7 @@ def test_log_if_unable_to_set_cached_max_record_value(
     captured = capsys.readouterr()
 
     assert 'ASSET=0 AC=0' in captured.out
-    assert 'Could not save data to cache.' in captured.out
+    assert 'Could not save data to cache. Details: Oops!.' in captured.out
     patch.assert_called_once()
 
 

--- a/tests/unit/test_task_app.py
+++ b/tests/unit/test_task_app.py
@@ -167,7 +167,7 @@ def test_log_if_unable_to_update_task_data(context, mocker: MockerFixture, capsy
     update_task_data_patch = mocker.patch.object(
         RawTaskEvent,
         'update_task_data',
-        side_effect=Exception,
+        side_effect=Exception('Oops!'),
     )
 
     task_app(event, context)
@@ -175,7 +175,7 @@ def test_log_if_unable_to_update_task_data(context, mocker: MockerFixture, capsy
     captured = capsys.readouterr()
 
     assert 'ASSET=0' in captured.out
-    assert 'Could not update task data.' in captured.out
+    assert 'Could not update task data. Details: Oops!.' in captured.out
     update_task_data_patch.assert_called_once()
 
 


### PR DESCRIPTION
### Rationale
Users get confused when they see internal SDK errors logged using `exception` level.

### Changes
Changed internal SDK errors to be logged using `warning` level.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-3321)

#### TODO
- [X] Update CHANGELOG.md
