### PR TITLE
DC-3467 App rerun support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Rerun support.
+`StreamTimeEvent`, `StreamDepthEvent`,
+`ScheduledDataTimeEvent`, `ScheduledDepthEvent`
+and `ScheduledNaturalTimeEvent` got new
+`rerun` field which stores rerun metadata.
+
 
 ## [1.4.0] - 2021-04-25
 

--- a/docs/modules/ROOT/examples/app_types/tutorial006.py
+++ b/docs/modules/ROOT/examples/app_types/tutorial006.py
@@ -1,5 +1,4 @@
-from corva import Api  # <1>
-from corva import Cache, ScheduledNaturalTimeEvent, scheduled
+from corva import Api, Cache, ScheduledNaturalTimeEvent, scheduled  # <1>
 
 
 @scheduled  # <3>

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -605,6 +605,25 @@ as `secrets` parameter.
 <.> {test-app-step5}
 
 
+== App rerun
+You might want to implement custom logic for app rerun,
+for this events include `rerun` field
+that stores rerun metadata.
+
+Example usage scenario of `rerun` field:
+
+. Well start 22/01/31 - end 22/03/31.
+
+. Rerun start 22/02/02 - end 22/02/04.
+
+. By default app uses the latest calculated record
+as the base to catch up to real-time.
+
+. During rerun app must use the latest record before 22/02/02 (using `rerun.start`)
+as the base for the initial calculation.
+
+
+
 == Development - Contributing
 
 Here are some guidelines to set up your environment.

--- a/src/corva/__init__.py
+++ b/src/corva/__init__.py
@@ -1,6 +1,7 @@
 from .api import Api
 from .handlers import scheduled, stream, task
 from .logger import CORVA_LOGGER as Logger
+from .models.rerun import RerunDepth, RerunDepthRange, RerunTime, RerunTimeRange
 from .models.scheduled.scheduled import (
     ScheduledDataTimeEvent,
     ScheduledDepthEvent,

--- a/src/corva/models/rerun.py
+++ b/src/corva/models/rerun.py
@@ -1,0 +1,45 @@
+import pydantic
+
+from corva.models import base, validators
+
+
+class RerunDepthRange(base.CorvaBaseEvent):
+    start: float
+    end: float
+
+
+class RerunTimeRange(base.CorvaBaseEvent):
+    start: int
+    end: int
+
+    # validators
+    _set_start = pydantic.validator('start', allow_reuse=True)(validators.from_ms_to_s)
+    _set_end = pydantic.validator('end', allow_reuse=True)(validators.from_ms_to_s)
+
+
+class RerunTime(base.CorvaBaseEvent):
+    """Rerun metadata for time event.
+
+    Attributes:
+        range: rerun time range.
+        invoke: invoke counter.
+        total: total invoke count for the rerun.
+    """
+
+    range: RerunTimeRange
+    invoke: int
+    total: int
+
+
+class RerunDepth(base.CorvaBaseEvent):
+    """Rerun metadata for depth event.
+
+    Attributes:
+        range: rerun depth range.
+        invoke: invoke counter.
+        total: total invoke count for the rerun.
+    """
+
+    range: RerunDepthRange
+    invoke: int
+    total: int

--- a/src/corva/models/rerun.py
+++ b/src/corva/models/rerun.py
@@ -4,11 +4,25 @@ from corva.models import base, validators
 
 
 class RerunDepthRange(base.CorvaBaseEvent):
+    """Rerun depth range metadata.
+
+    Attributes:
+        start: start depth.
+        end: end depth.
+    """
+
     start: float
     end: float
 
 
 class RerunTimeRange(base.CorvaBaseEvent):
+    """Rerun time range metadata.
+
+    Attributes:
+        start: start time.
+        end: end time.
+    """
+
     start: int
     end: int
 

--- a/src/corva/models/scheduled/raw.py
+++ b/src/corva/models/scheduled/raw.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pydantic
 
 from corva.api import Api
 from corva.models import validators
 from corva.models.base import CorvaBaseEvent, RawBaseEvent
+from corva.models.rerun import RerunDepth, RerunTime
 from corva.models.scheduled.scheduler_type import SchedulerType
 
 
@@ -63,11 +64,13 @@ class RawScheduledDataTimeEvent(RawScheduledEvent):
         start_time: left bound of the time range, covered by this event.
             Use inclusively.
         interval: time between two schedule triggers.
+        rerun: rerun metadata.
     """
 
     schedule_start: int
     start_time: int = None  # type: ignore
     interval: float
+    rerun: Optional[RerunTime] = None
 
     # validators
     _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(
@@ -91,12 +94,14 @@ class RawScheduledDepthEvent(RawScheduledEvent):
         log_identifier: app stream log identifier. Used to scope data by stream,
             asset might be connected to multiple depth based logs.
         interval: distance between two schedule triggers.
+        rerun: rerun metadata.
     """
 
     top_depth: float
     bottom_depth: float
     log_identifier: str
     interval: float = pydantic.Field(..., alias='depth_milestone')
+    rerun: Optional[RerunDepth] = None
 
 
 class RawScheduledNaturalTimeEvent(RawScheduledEvent):
@@ -105,10 +110,12 @@ class RawScheduledNaturalTimeEvent(RawScheduledEvent):
     Attributes:
         schedule_start: Unix timestamp, when the schedule was triggered.
         interval: time between two schedule triggers.
+        rerun: rerun metadata.
     """
 
     schedule_start: int
     interval: float
+    rerun: Optional[RerunTime] = None
 
     # validators
     _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(

--- a/src/corva/models/scheduled/raw.py
+++ b/src/corva/models/scheduled/raw.py
@@ -6,22 +6,9 @@ from typing import List, Union
 import pydantic
 
 from corva.api import Api
+from corva.models import validators
 from corva.models.base import CorvaBaseEvent, RawBaseEvent
 from corva.models.scheduled.scheduler_type import SchedulerType
-
-
-def set_schedule_start(schedule_start: int) -> int:
-    """Casts Unix timestamp from milliseconds to seconds.
-
-    Casts Unix timestamp from millisecond to seconds, if provided timestamp is in
-        milliseconds.
-    """
-
-    # 1 January 10000 00:00:00 - first date to not fit into the datetime instance
-    if schedule_start >= 253402300800:
-        schedule_start //= 1000
-
-    return schedule_start
 
 
 class RawScheduledEvent(CorvaBaseEvent, RawBaseEvent):
@@ -84,7 +71,7 @@ class RawScheduledDataTimeEvent(RawScheduledEvent):
 
     # validators
     _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(
-        set_schedule_start
+        validators.from_ms_to_s
     )
 
     @pydantic.root_validator(pre=False, skip_on_failure=True)
@@ -125,5 +112,5 @@ class RawScheduledNaturalTimeEvent(RawScheduledEvent):
 
     # validators
     _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(
-        set_schedule_start
+        validators.from_ms_to_s
     )

--- a/src/corva/models/scheduled/scheduled.py
+++ b/src/corva/models/scheduled/scheduled.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 import pydantic
 
 from corva.models.base import CorvaBaseEvent
+from corva.models.rerun import RerunDepth, RerunTime
 
 
 class ScheduledEvent(CorvaBaseEvent):
@@ -22,12 +25,14 @@ class ScheduledDataTimeEvent(ScheduledEvent):
             Use inclusively.
         end_time: right bound of the time range, covered by this event.
             Use inclusively.
+        rerun: rerun metadata.
     """
 
     asset_id: int
     company_id: int
     start_time: int
     end_time: int = pydantic.Field(..., alias='schedule_start')
+    rerun: Optional[RerunTime] = None
 
     class Config:
         allow_population_by_field_name = True
@@ -49,6 +54,7 @@ class ScheduledDepthEvent(ScheduledEvent):
         log_identifier: app stream log identifier. Used to scope data by stream,
             asset might be connected to multiple depth based logs.
         interval: distance between two schedule triggers.
+        rerun: rerun metadata.
     """
 
     asset_id: int
@@ -57,6 +63,7 @@ class ScheduledDepthEvent(ScheduledEvent):
     bottom_depth: float
     log_identifier: str
     interval: float
+    rerun: Optional[RerunDepth] = None
 
 
 class ScheduledNaturalTimeEvent(ScheduledEvent):
@@ -70,9 +77,11 @@ class ScheduledNaturalTimeEvent(ScheduledEvent):
         company_id: company id.
         schedule_start: schedule trigger time.
         interval: time between two schedule triggers.
+        rerun: rerun metadata.
     """
 
     asset_id: int
     company_id: int
     schedule_start: int
     interval: float
+    rerun: Optional[RerunTime] = None

--- a/src/corva/models/stream/raw.py
+++ b/src/corva/models/stream/raw.py
@@ -8,6 +8,7 @@ import pydantic
 
 from corva.configuration import SETTINGS
 from corva.models.base import CorvaBaseEvent, RawBaseEvent
+from corva.models.rerun import RerunDepth, RerunTime
 from corva.models.stream.initial import InitialStreamEvent
 from corva.models.stream.log_type import LogType
 from corva.service.cache_sdk import UserCacheSdkProtocol
@@ -181,9 +182,11 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
 
 class RawStreamTimeEvent(RawStreamEvent):
     records: RecordsTime
+    rerun: Optional[RerunTime] = None
     _max_record_value_cache_key: ClassVar[str] = 'last_processed_timestamp'
 
 
 class RawStreamDepthEvent(RawStreamEvent):
     records: RecordsDepth
+    rerun: Optional[RerunDepth] = None
     _max_record_value_cache_key: ClassVar[str] = 'last_processed_depth'

--- a/src/corva/models/stream/stream.py
+++ b/src/corva/models/stream/stream.py
@@ -1,15 +1,12 @@
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import pydantic
 
 from corva.models.base import CorvaBaseEvent
+from corva.models.rerun import RerunDepth, RerunTime
 
 
-class StreamBaseRecord(CorvaBaseEvent):
-    """Stream base record data."""
-
-
-class StreamTimeRecord(StreamBaseRecord):
+class StreamTimeRecord(CorvaBaseEvent):
     """Stream time record data.
 
     Attributes:
@@ -23,7 +20,7 @@ class StreamTimeRecord(StreamBaseRecord):
     metadata: dict = {}
 
 
-class StreamDepthRecord(StreamBaseRecord):
+class StreamDepthRecord(CorvaBaseEvent):
     """Stream depth record data.
 
     Attributes:
@@ -38,36 +35,44 @@ class StreamDepthRecord(StreamBaseRecord):
 
 
 if TYPE_CHECKING:
-    RecordsBase = Sequence[StreamBaseRecord]
     RecordsTime = Sequence[StreamTimeRecord]
     RecordsDepth = Sequence[StreamDepthRecord]
 else:
-    RecordsBase = pydantic.conlist(StreamBaseRecord, min_items=1)
     RecordsTime = pydantic.conlist(StreamTimeRecord, min_items=1)
     RecordsDepth = pydantic.conlist(StreamDepthRecord, min_items=1)
 
 
 class StreamEvent(CorvaBaseEvent):
-    """Stream event data.
+    """Base stream event data."""
+
+
+class StreamTimeEvent(StreamEvent):
+    """Stream time event data.
 
     Attributes:
         asset_id: asset id.
         company_id: company id.
         records: data records.
+        rerun: rerun metadata.
     """
 
     asset_id: int
     company_id: int
-    records: RecordsBase
-
-
-class StreamTimeEvent(StreamEvent):
-    """Stream time event data."""
-
     records: RecordsTime
+    rerun: Optional[RerunTime] = None
 
 
 class StreamDepthEvent(StreamEvent):
-    """Stream depth event data."""
+    """Stream depth event data.
 
+    Attributes:
+        asset_id: asset id.
+        company_id: company id.
+        records: data records.
+        rerun: rerun metadata.
+    """
+
+    asset_id: int
+    company_id: int
     records: RecordsDepth
+    rerun: Optional[RerunDepth] = None

--- a/src/corva/models/validators.py
+++ b/src/corva/models/validators.py
@@ -1,0 +1,12 @@
+def from_ms_to_s(timestamp: int) -> int:
+    """Casts Unix timestamp from milliseconds to seconds.
+
+    Casts Unix timestamp from millisecond to seconds, if provided timestamp is in
+        milliseconds.
+    """
+
+    # 1 January 10000 00:00:00 - first date to not fit into the datetime instance
+    if timestamp >= 253402300800:
+        timestamp //= 1000
+
+    return timestamp

--- a/tests/unit/test_rerun.py
+++ b/tests/unit/test_rerun.py
@@ -1,0 +1,104 @@
+from corva import (
+    Api,
+    Cache,
+    RerunDepth,
+    RerunDepthRange,
+    RerunTime,
+    RerunTimeRange,
+    ScheduledDataTimeEvent,
+    ScheduledDepthEvent,
+    ScheduledNaturalTimeEvent,
+    StreamDepthEvent,
+    StreamDepthRecord,
+    StreamTimeEvent,
+    StreamTimeRecord,
+    scheduled,
+    stream,
+)
+
+
+@stream
+def stream_time_app(event: StreamTimeEvent, api: Api, cache: Cache):
+    assert event.rerun
+
+
+@stream
+def stream_depth_app(event: StreamDepthEvent, api: Api, cache: Cache):
+    assert event.rerun
+
+
+@scheduled
+def scheduled_data_time_app(event: ScheduledDataTimeEvent, api: Api, cache: Cache):
+    assert event.rerun
+
+
+@scheduled
+def scheduled_depth_app(event: ScheduledDepthEvent, api: Api, cache: Cache):
+    assert event.rerun
+
+
+@scheduled
+def scheduled_natural_time_app(
+    event: ScheduledNaturalTimeEvent, api: Api, cache: Cache
+):
+    assert event.rerun
+
+
+def test_stream_time_app(app_runner):
+    event = StreamTimeEvent(
+        asset_id=0,
+        company_id=0,
+        records=[StreamTimeRecord(timestamp=0)],
+        rerun=RerunTime(range=RerunTimeRange(start=0, end=0), invoke=0, total=0),
+    )
+
+    app_runner(stream_time_app, event)
+
+
+def test_stream_depth_app(app_runner):
+    event = StreamDepthEvent(
+        asset_id=0,
+        company_id=0,
+        records=[StreamDepthRecord(measured_depth=0)],
+        rerun=RerunDepth(range=RerunDepthRange(start=0.0, end=0.0), invoke=0, total=0),
+    )
+
+    app_runner(stream_depth_app, event)
+
+
+def test_scheduled_data_time_app(app_runner):
+    event = ScheduledDataTimeEvent(
+        asset_id=0,
+        start_time=0,
+        end_time=0,
+        company_id=0,
+        rerun=RerunTime(range=RerunTimeRange(start=0, end=0), invoke=0, total=0),
+    )
+
+    app_runner(scheduled_data_time_app, event)
+
+
+def test_scheduled_depth_app(app_runner):
+    event = ScheduledDepthEvent(
+        asset_id=0,
+        company_id=0,
+        top_depth=0.0,
+        bottom_depth=1.0,
+        log_identifier='',
+        interval=1.0,
+        rerun=RerunDepth(range=RerunDepthRange(start=0.0, end=0.0), invoke=0, total=0),
+    )
+
+    app_runner(scheduled_depth_app, event)
+
+
+def test_scheduled_natural_time_app(app_runner):
+    event = ScheduledNaturalTimeEvent(
+        asset_id=0,
+        company_id=0,
+        schedule_start=0,
+        interval=1,
+        rerun=RerunTime(range=RerunTimeRange(start=0, end=0), invoke=0, total=0),
+    )
+
+    app_runner(scheduled_natural_time_app, event)

--- a/tests/unit/test_scheduled_app.py
+++ b/tests/unit/test_scheduled_app.py
@@ -372,6 +372,7 @@ def test_rerun_data_time_cast_from_ms_to_s(
 
     result_event: ScheduledDataTimeEvent = app(event, context)[0]
 
+    assert result_event.rerun is not None  # for mypy to not complain.
     assert result_event.rerun.range.start == expected
     assert result_event.rerun.range.end == expected
 
@@ -410,5 +411,6 @@ def test_rerun_natural_time_cast_from_ms_to_s(
 
     result_event: ScheduledNaturalTimeEvent = app(event, context)[0]
 
+    assert result_event.rerun is not None  # for mypy to not complain.
     assert result_event.rerun.range.start == expected
     assert result_event.rerun.range.end == expected


### PR DESCRIPTION
### Rationale
Users might need to use rerun metadata to implement custom rerun logic in their apps.

### Changes
Added rerun support. `StreamTimeEvent`, `StreamDepthEvent`, `ScheduledDataTimeEvent`, `ScheduledDepthEvent` and `ScheduledNaturalTimeEvent` got new `rerun` field which stores rerun metadata.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-3467)

#### TODO
- [X] Update CHANGELOG.md
