### PR TITLE
Added the functionality to reuse cache in app_runner

### DIFF
--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -33,24 +33,24 @@ class Api:
     @property
     def default_headers(self):
         return {
-            'Authorization': f'API {self.api_key}',
-            'X-Corva-App': self.app_key,
+            "Authorization": f"API {self.api_key}",
+            "X-Corva-App": self.app_key,
         }
 
     def get(self, path: str, **kwargs):
-        return self._request('GET', path, **kwargs)
+        return self._request("GET", path, **kwargs)
 
     def post(self, path: str, **kwargs):
-        return self._request('POST', path, **kwargs)
+        return self._request("POST", path, **kwargs)
 
     def patch(self, path: str, **kwargs):
-        return self._request('PATCH', path, **kwargs)
+        return self._request("PATCH", path, **kwargs)
 
     def put(self, path: str, **kwargs):
-        return self._request('PUT', path, **kwargs)
+        return self._request("PUT", path, **kwargs)
 
     def delete(self, path: str, **kwargs):
-        return self._request('DELETE', path, **kwargs)
+        return self._request("DELETE", path, **kwargs)
 
     def _get_url(self, path: str):
         """Builds complete url.
@@ -64,15 +64,15 @@ class Api:
           3 corva api url, if above points are False.
         """
 
-        if path.startswith('http'):
+        if path.startswith("http"):
             return path
 
         path = path.lstrip(
-            '/'
+            "/"
         )  # delete leading forward slash for posixpath.join to work correctly
 
         # search text like api/v1 or api/v10 in path
-        if bool(re.search(r'api/v\d+', path)):
+        if bool(re.search(r"api/v\d+", path)):
             return posixpath.join(self.data_api_url, path)
 
         return posixpath.join(self.api_url, path)
@@ -125,8 +125,8 @@ class Api:
     def _validate_timeout(self, timeout: int) -> None:
         if self.TIMEOUT_LIMITS[0] > timeout or self.TIMEOUT_LIMITS[1] < timeout:
             raise ValueError(
-                f'Timeout must be between {self.TIMEOUT_LIMITS[0]} and '
-                f'{self.TIMEOUT_LIMITS[1]} seconds.'
+                f"Timeout must be between {self.TIMEOUT_LIMITS[0]} and "
+                f"{self.TIMEOUT_LIMITS[1]} seconds."
             )
 
     def get_dataset(
@@ -164,13 +164,13 @@ class Api:
         """
 
         response = self.get(
-            f'/api/v1/data/{provider}/{dataset}/',
+            f"/api/v1/data/{provider}/{dataset}/",
             params={
-                'query': json.dumps(query),
-                'sort': json.dumps(sort),
-                'fields': fields,
-                'limit': limit,
-                'skip': skip,
+                "query": json.dumps(query),
+                "sort": json.dumps(sort),
+                "fields": fields,
+                "limit": limit,
+                "skip": skip,
             },
         )
         response.raise_for_status()

--- a/src/corva/cache_adapter.py
+++ b/src/corva/cache_adapter.py
@@ -196,7 +196,7 @@ class RedisRepository:
 
     def __init__(self, hash_name: str, client: redis.Redis, use_lua_52: bool = False):
         self.hash_name = hash_name
-        self.zset_name = f'{hash_name}.EXPIREAT'
+        self.zset_name = f"{hash_name}.EXPIREAT"
         self.client = client
         self.lua_set_many = self.client.register_script(self.LUA_SET_SCRIPT)
 
@@ -205,7 +205,7 @@ class RedisRepository:
             # Hack for tests to work with fakeredis, as it uses Lua version > 5.1.
             # In Lua 5.1, unpack was a global, but in 5.2 it's been moved to
             # table.unpack.
-            lua_get_script = self.LUA_GET_SCRIPT.replace('unpack', 'table.unpack')
+            lua_get_script = self.LUA_GET_SCRIPT.replace("unpack", "table.unpack")
         self.lua_get = self.client.register_script(lua_get_script)
 
         self.lua_vacuum = self.client.register_script(self.LUA_VACUUM_SCRIPT)
@@ -240,7 +240,7 @@ class RedisRepository:
         self.delete_many(keys=[key])
 
     def delete_many(self, keys: Sequence[str]) -> None:
-        self.set_many(data=[(key, '', -1) for key in keys])
+        self.set_many(data=[(key, "", -1) for key in keys])
 
     def delete_all(self) -> None:
         self.lua_delete_all(keys=[self.hash_name, self.zset_name])

--- a/src/corva/configuration.py
+++ b/src/corva/configuration.py
@@ -12,7 +12,7 @@ class Settings(pydantic.BaseSettings):
     CACHE_URL: str
 
     # logger
-    LOG_LEVEL: str = 'INFO'
+    LOG_LEVEL: str = "INFO"
     LOG_THRESHOLD_MESSAGE_SIZE: int = 1000
     LOG_THRESHOLD_MESSAGE_COUNT: int = 15
 

--- a/src/corva/handlers.py
+++ b/src/corva/handlers.py
@@ -18,8 +18,8 @@ from corva.service import service
 from corva.service.api_sdk import CachingApiSdk, CorvaApiSdk
 from corva.service.cache_sdk import FakeInternalCacheSdk, InternalRedisSdk, UserRedisSdk
 
-StreamEventT = TypeVar('StreamEventT', bound=StreamEvent)
-ScheduledEventT = TypeVar('ScheduledEventT', bound=ScheduledEvent)
+StreamEventT = TypeVar("StreamEventT", bound=StreamEvent)
+ScheduledEventT = TypeVar("ScheduledEventT", bound=ScheduledEvent)
 
 
 def get_cache_key(
@@ -30,8 +30,8 @@ def get_cache_key(
     app_connection_id: int,
 ) -> str:
     return (
-        f'{provider}/well/{asset_id}/stream/{app_stream_id}/'
-        f'{app_key}/{app_connection_id}'
+        f"{provider}/well/{asset_id}/stream/{app_stream_id}/"
+        f"{app_key}/{app_connection_id}"
     )
 
 
@@ -73,7 +73,7 @@ def base_handler(
                 return results
 
             except Exception:
-                CORVA_LOGGER.exception('The app failed to execute.')
+                CORVA_LOGGER.exception("The app failed to execute.")
                 raise
 
     return wrapper
@@ -126,7 +126,7 @@ def stream(
             return
 
         app_event = event.metadata.log_type.event.parse_obj(
-            event.copy(update={'records': records}, deep=True)
+            event.copy(update={"records": records}, deep=True)
         )
         with LoggingContext(
             aws_request_id=aws_request_id,
@@ -136,7 +136,7 @@ def stream(
                 max_message_size=SETTINGS.LOG_THRESHOLD_MESSAGE_SIZE,
                 max_message_count=SETTINGS.LOG_THRESHOLD_MESSAGE_COUNT,
                 logger=CORVA_LOGGER,
-                placeholder=' ...',
+                placeholder=" ...",
             ),
             user_handler=handler,
             logger=CORVA_LOGGER,
@@ -161,7 +161,7 @@ def stream(
             event.set_cached_max_record_value(cache=user_cache_sdk)
         except Exception as e:
             # lambda succeeds if we're unable to cache the value
-            CORVA_LOGGER.warning(f'Could not save data to cache. Details: {str(e)}.')
+            CORVA_LOGGER.warning(f"Could not save data to cache. Details: {str(e)}.")
 
         return result
 
@@ -216,7 +216,7 @@ def scheduled(
                 max_message_size=SETTINGS.LOG_THRESHOLD_MESSAGE_SIZE,
                 max_message_count=SETTINGS.LOG_THRESHOLD_MESSAGE_COUNT,
                 logger=CORVA_LOGGER,
-                placeholder=' ...',
+                placeholder=" ...",
             ),
             user_handler=handler,
             logger=CORVA_LOGGER,
@@ -254,7 +254,7 @@ def set_schedule_as_completed(event: RawScheduledEvent, api: Api) -> None:
         event.set_schedule_as_completed(api=api)
     except Exception as e:
         # lambda succeeds if we're unable to set completed status
-        CORVA_LOGGER.warning(f'Could not set schedule as completed. Details: {str(e)}.')
+        CORVA_LOGGER.warning(f"Could not set schedule as completed. Details: {str(e)}.")
 
 
 def task(
@@ -295,7 +295,7 @@ def task(
                     max_message_size=SETTINGS.LOG_THRESHOLD_MESSAGE_SIZE,
                     max_message_count=SETTINGS.LOG_THRESHOLD_MESSAGE_COUNT,
                     logger=CORVA_LOGGER,
-                    placeholder=' ...',
+                    placeholder=" ...",
                 ),
                 user_handler=handler,
                 logger=CORVA_LOGGER,
@@ -321,15 +321,15 @@ def task(
                     FutureWarning,
                 )
 
-                data['payload'] = result
+                data["payload"] = result
 
             status = TaskStatus.success
 
             return result
 
         except Exception as exc:
-            CORVA_LOGGER.exception('Task app failed to execute.')
-            data = {'fail_reason': str(exc)}
+            CORVA_LOGGER.exception("Task app failed to execute.")
+            data = {"fail_reason": str(exc)}
 
         finally:
             try:
@@ -340,6 +340,6 @@ def task(
                 ).raise_for_status()
             except Exception as e:
                 # lambda succeeds if we're unable to update task data
-                CORVA_LOGGER.warning(f'Could not update task data. Details: {str(e)}.')
+                CORVA_LOGGER.warning(f"Could not update task data. Details: {str(e)}.")
 
     return wrapper

--- a/src/corva/logger.py
+++ b/src/corva/logger.py
@@ -9,7 +9,7 @@ from corva.configuration import SETTINGS
 
 logging.Formatter.converter = time.gmtime  # log time as UTC
 
-CORVA_LOGGER = logging.getLogger('corva')
+CORVA_LOGGER = logging.getLogger("corva")
 CORVA_LOGGER.setLevel(SETTINGS.LOG_LEVEL)
 CORVA_LOGGER.propagate = False  # do not pass messages to ancestor loggers
 
@@ -18,13 +18,13 @@ def get_formatter(
     aws_request_id: bool, asset_id: bool, app_connection_id: bool
 ) -> logging.Formatter:
     return logging.Formatter(
-        f'%(asctime)s.%(msecs)03dZ '
+        f"%(asctime)s.%(msecs)03dZ "
         f'{"%(aws_request_id)s " if aws_request_id else ""}'
-        f'%(levelname)s '
+        f"%(levelname)s "
         f'{"ASSET=%(asset_id)s " if asset_id else ""}'
         f'{"AC=%(app_connection_id)s " if app_connection_id else ""}'
-        f'| %(message)s',
-        '%Y-%m-%dT%H:%M:%S',
+        f"| %(message)s",
+        "%Y-%m-%dT%H:%M:%S",
     )
 
 
@@ -70,7 +70,7 @@ class CorvaLoggerHandler(logging.Handler):
             if it has been truncated.
     """
 
-    TERMINATOR = '\n'
+    TERMINATOR = "\n"
 
     def __init__(
         self,
@@ -84,7 +84,7 @@ class CorvaLoggerHandler(logging.Handler):
         self.max_message_size = max_message_size
         self.max_message_count = max_message_count
         self.logger = logger
-        self.placeholder = f'{placeholder}{self.TERMINATOR}'
+        self.placeholder = f"{placeholder}{self.TERMINATOR}"
 
         self.logging_warning = False
         # one extra message to log the warning
@@ -101,8 +101,8 @@ class CorvaLoggerHandler(logging.Handler):
         if self.residue_message_count == 1:
             self.logging_warning = True
             self.logger.warning(
-                f'Disabling the logging as maximum number of logged messages '
-                f'was reached: {self.max_message_count}.'
+                f"Disabling the logging as maximum number of logged messages "
+                f"was reached: {self.max_message_count}."
             )
 
     def format(self, record: logging.LogRecord) -> str:
@@ -112,8 +112,8 @@ class CorvaLoggerHandler(logging.Handler):
         # For CloudWatch `\n` means end of whole log and `\r` means end of line in
         # multiline logs.
         # Replace `\n` for `\r` for logs to display correctly in CloudWatch.
-        message = message.replace('\n', '\r')
-        message = f'{message}{self.TERMINATOR}'
+        message = message.replace("\n", "\r")
+        message = f"{message}{self.TERMINATOR}"
 
         extra_chars_count = len(message) - self.max_message_size
 
@@ -124,7 +124,7 @@ class CorvaLoggerHandler(logging.Handler):
         message_end_idx = len(message) - (extra_chars_count + len(self.placeholder))
 
         if message_end_idx <= 0:
-            return ''
+            return ""
 
         message = message[:message_end_idx] + self.placeholder
 

--- a/src/corva/models/context.py
+++ b/src/corva/models/context.py
@@ -42,7 +42,7 @@ class CorvaContext(pydantic.BaseModel):
         if aws_context.client_context is None:
             parse_ctx = mock.patch.object(
                 aws_context,
-                'client_context',
+                "client_context",
                 AwsEventWithClientContext.parse_obj(aws_event).client_context,
             )
 

--- a/src/corva/models/rerun.py
+++ b/src/corva/models/rerun.py
@@ -27,8 +27,8 @@ class RerunTimeRange(base.CorvaBaseEvent):
     end: int
 
     # validators
-    _set_start = pydantic.validator('start', allow_reuse=True)(validators.from_ms_to_s)
-    _set_end = pydantic.validator('end', allow_reuse=True)(validators.from_ms_to_s)
+    _set_start = pydantic.validator("start", allow_reuse=True)(validators.from_ms_to_s)
+    _set_end = pydantic.validator("end", allow_reuse=True)(validators.from_ms_to_s)
 
 
 class RerunTime(base.CorvaBaseEvent):

--- a/src/corva/models/scheduled/raw.py
+++ b/src/corva/models/scheduled/raw.py
@@ -25,10 +25,10 @@ class RawScheduledEvent(CorvaBaseEvent, RawBaseEvent):
     """
 
     asset_id: int
-    company_id: int = pydantic.Field(..., alias='company')
-    schedule_id: int = pydantic.Field(..., alias='schedule')
-    app_connection_id: int = pydantic.Field(..., alias='app_connection')
-    app_stream_id: int = pydantic.Field(..., alias='app_stream')
+    company_id: int = pydantic.Field(..., alias="company")
+    schedule_id: int = pydantic.Field(..., alias="schedule")
+    app_connection_id: int = pydantic.Field(..., alias="app_connection")
+    app_stream_id: int = pydantic.Field(..., alias="app_stream")
     scheduler_type: SchedulerType
     has_secrets: bool = False
 
@@ -53,7 +53,7 @@ class RawScheduledEvent(CorvaBaseEvent, RawBaseEvent):
 
     def set_schedule_as_completed(self, api: Api) -> None:
         """Sets schedule as completed."""
-        api.post(path=f'scheduler/{self.schedule_id}/completed')
+        api.post(path=f"scheduler/{self.schedule_id}/completed")
 
 
 class RawScheduledDataTimeEvent(RawScheduledEvent):
@@ -73,7 +73,7 @@ class RawScheduledDataTimeEvent(RawScheduledEvent):
     rerun: Optional[RerunTime] = None
 
     # validators
-    _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(
+    _set_schedule_start = pydantic.validator("schedule_start", allow_reuse=True)(
         validators.from_ms_to_s
     )
 
@@ -100,7 +100,7 @@ class RawScheduledDepthEvent(RawScheduledEvent):
     top_depth: float
     bottom_depth: float
     log_identifier: str
-    interval: float = pydantic.Field(..., alias='depth_milestone')
+    interval: float = pydantic.Field(..., alias="depth_milestone")
     rerun: Optional[RerunDepth] = None
 
 
@@ -118,6 +118,6 @@ class RawScheduledNaturalTimeEvent(RawScheduledEvent):
     rerun: Optional[RerunTime] = None
 
     # validators
-    _set_schedule_start = pydantic.validator('schedule_start', allow_reuse=True)(
+    _set_schedule_start = pydantic.validator("schedule_start", allow_reuse=True)(
         validators.from_ms_to_s
     )

--- a/src/corva/models/scheduled/scheduled.py
+++ b/src/corva/models/scheduled/scheduled.py
@@ -31,7 +31,7 @@ class ScheduledDataTimeEvent(ScheduledEvent):
     asset_id: int
     company_id: int
     start_time: int
-    end_time: int = pydantic.Field(..., alias='schedule_start')
+    end_time: int = pydantic.Field(..., alias="schedule_start")
     rerun: Optional[RerunTime] = None
 
     class Config:

--- a/src/corva/models/stream/log_type.py
+++ b/src/corva/models/stream/log_type.py
@@ -2,8 +2,8 @@ import enum
 
 
 class LogType(enum.Enum):
-    time = 'time'
-    depth = 'depth'
+    time = "time"
+    depth = "depth"
 
     @property
     def raw_event(self):

--- a/src/corva/models/stream/raw.py
+++ b/src/corva/models/stream/raw.py
@@ -103,7 +103,7 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
         There can only be 1 completed record always located at the end of the list.
         """
 
-        return self.records[-1].collection == 'wits.completed'
+        return self.records[-1].collection == "wits.completed"
 
     @property
     def max_record_value(self) -> Union[int, float]:
@@ -163,7 +163,7 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
     def set_asset_id(cls, values: dict) -> dict:
         """Calculates asset_id field."""
 
-        records: List[RawBaseRecord] = values['records']
+        records: List[RawBaseRecord] = values["records"]
 
         values["asset_id"] = int(records[0].asset_id)
 
@@ -173,7 +173,7 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
     def set_company_id(cls, values: dict) -> dict:
         """Calculates company_id field."""
 
-        records: List[RawBaseRecord] = values['records']
+        records: List[RawBaseRecord] = values["records"]
 
         values["company_id"] = int(records[0].company_id)
 
@@ -183,10 +183,10 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
 class RawStreamTimeEvent(RawStreamEvent):
     records: RecordsTime
     rerun: Optional[RerunTime] = None
-    _max_record_value_cache_key: ClassVar[str] = 'last_processed_timestamp'
+    _max_record_value_cache_key: ClassVar[str] = "last_processed_timestamp"
 
 
 class RawStreamDepthEvent(RawStreamEvent):
     records: RecordsDepth
     rerun: Optional[RerunDepth] = None
-    _max_record_value_cache_key: ClassVar[str] = 'last_processed_depth'
+    _max_record_value_cache_key: ClassVar[str] = "last_processed_depth"

--- a/src/corva/models/task.py
+++ b/src/corva/models/task.py
@@ -11,8 +11,8 @@ from corva.models.base import CorvaBaseEvent, RawBaseEvent
 
 
 class TaskStatus(enum.Enum):
-    fail = 'fail'
-    success = 'success'
+    fail = "fail"
+    success = "success"
 
 
 class TaskEvent(CorvaBaseEvent):
@@ -39,7 +39,7 @@ class RawTaskEvent(CorvaBaseEvent, RawBaseEvent):
         return [pydantic.parse_obj_as(RawTaskEvent, event)]
 
     def get_task_event(self, api: Api) -> TaskEvent:
-        response = api.get(path=f'v2/tasks/{self.task_id}')
+        response = api.get(path=f"v2/tasks/{self.task_id}")
         response.raise_for_status()
 
         return TaskEvent(**response.json())
@@ -49,4 +49,4 @@ class RawTaskEvent(CorvaBaseEvent, RawBaseEvent):
     ) -> requests.Response:
         """Updates the task."""
 
-        return api.put(path=f'v2/tasks/{self.task_id}/{status.value}', data=data)
+        return api.put(path=f"v2/tasks/{self.task_id}/{status.value}", data=data)

--- a/src/corva/service/api_sdk.py
+++ b/src/corva/service/api_sdk.py
@@ -39,7 +39,7 @@ class CorvaApiSdk:
 
     def get_secrets(self, app_key: str) -> Dict[str, str]:
         response = self.api_adapter.get(
-            path=f'/v2/apps/secrets/values?app_key={app_key}'
+            path=f"/v2/apps/secrets/values?app_key={app_key}"
         )
         secrets = response.json()
         return secrets

--- a/src/corva/testing.py
+++ b/src/corva/testing.py
@@ -22,12 +22,12 @@ class TestClient:
     """
 
     _context: ClassVar[SimpleNamespace] = SimpleNamespace(
-        aws_request_id='qwerty', client_context=SimpleNamespace(env={'API_KEY': '123'})
+        aws_request_id="qwerty", client_context=SimpleNamespace(env={"API_KEY": "123"})
     )
     _api: ClassVar[Api] = Api(
         api_url=SETTINGS.API_ROOT_URL,
         data_api_url=SETTINGS.DATA_API_ROOT_URL,
-        api_key=_context.client_context.env['API_KEY'],
+        api_key=_context.client_context.env["API_KEY"],
         app_key=SETTINGS.APP_KEY,
     )
 
@@ -48,7 +48,7 @@ class TestClient:
         if isinstance(event, (ScheduledEvent, StreamEvent)):
             if not cache:
                 cache = UserRedisSdk(
-                    hash_name='hash_name',
+                    hash_name="hash_name",
                     redis_dsn=SETTINGS.CACHE_URL,
                     use_fakes=True,
                 )
@@ -62,8 +62,8 @@ class TestClient:
 
         return service.run_app(
             has_secrets=True,
-            app_key='test_app_key',
-            api_sdk=FakeApiSdk(secrets={'test_app_key': secrets or {}}),
+            app_key="test_app_key",
+            api_sdk=FakeApiSdk(secrets={"test_app_key": secrets or {}}),
             cache_sdk=FakeInternalCacheSdk(),
             app=app,
         )

--- a/src/corva/testing.py
+++ b/src/corva/testing.py
@@ -36,7 +36,8 @@ class TestClient:
         fn: Callable,
         event: Union[TaskEvent, StreamEvent, ScheduledEvent],
         *,
-        secrets: Optional[Dict[str, str]] = None
+        secrets: Optional[Dict[str, str]] = None,
+        cache: UserRedisSdk = None,
     ) -> Any:
 
         app: Callable[[], Any]
@@ -45,15 +46,18 @@ class TestClient:
             app = functools.partial(inspect.unwrap(fn), event, TestClient._api)
 
         if isinstance(event, (ScheduledEvent, StreamEvent)):
+            if not cache:
+                cache = UserRedisSdk(
+                    hash_name='hash_name',
+                    redis_dsn=SETTINGS.CACHE_URL,
+                    use_fakes=True,
+                )
+
             app = functools.partial(
                 inspect.unwrap(fn),
                 event,
                 TestClient._api,
-                UserRedisSdk(
-                    hash_name='hash_name',
-                    redis_dsn=SETTINGS.CACHE_URL,
-                    use_fakes=True,
-                ),
+                cache,
             )
 
         return service.run_app(

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def app_runner():
     """Returns a function that should be used to run apps in tests."""
 
@@ -29,13 +29,13 @@ def pytest_load_initial_conftests(args, early_config, parser):
         https://docs.pytest.org/en/stable/writing_plugins.html#plugin-discovery-order-at-tool-startup
     """
 
-    provider = 'test-provider'
+    provider = "test-provider"
     env = {
-        'API_ROOT_URL': 'https://api.localhost.ai',
-        'DATA_API_ROOT_URL': 'https://data.localhost.ai',
-        'CACHE_URL': 'redis://localhost:6379',
-        'APP_KEY': f'{provider}.test-app-name',
-        'PROVIDER': provider,
+        "API_ROOT_URL": "https://api.localhost.ai",
+        "DATA_API_ROOT_URL": "https://data.localhost.ai",
+        "CACHE_URL": "redis://localhost:6379",
+        "APP_KEY": f"{provider}.test-app-name",
+        "PROVIDER": provider,
         **os.environ,  # override env values if provided by user
     }
     os.environ.update(env)

--- a/tests/integration/test_redis_repository.py
+++ b/tests/integration/test_redis_repository.py
@@ -6,10 +6,10 @@ import redis
 
 from corva import cache_adapter, configuration
 
-HASH_NAME = 'test_hash_name'
+HASH_NAME = "test_hash_name"
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def redis_client() -> Iterable[redis.Redis]:
     redis_client = redis.Redis.from_url(
         url=configuration.SETTINGS.CACHE_URL, decode_responses=True
@@ -22,7 +22,7 @@ def redis_client() -> Iterable[redis.Redis]:
     redis_client.flushall()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def redis_adapter(
     redis_client: redis.Redis,
 ) -> Iterable[cache_adapter.RedisRepository]:
@@ -39,27 +39,27 @@ class TestVacuumScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set(key='key1', value='value1', ttl=1)
-        redis_adapter.set(key='key2', value='value2', ttl=-1)
-        redis_adapter.set(key='key3', value='value3', ttl=-2)
+        redis_adapter.set(key="key1", value="value1", ttl=1)
+        redis_adapter.set(key="key2", value="value2", ttl=-1)
+        redis_adapter.set(key="key3", value="value3", ttl=-2)
 
         redis_adapter.vacuum(delete_count=1)
         assert redis_client.hgetall(name=redis_adapter.hash_name) == {
-            'key1': 'value1',
-            'key2': 'value2',
+            "key1": "value1",
+            "key2": "value2",
         }
         assert set(
             redis_client.zrange(name=redis_adapter.zset_name, start=0, end=-1)
-        ) == {'key2', 'key1'}
+        ) == {"key2", "key1"}
 
     def test_does_not_fail_for_empty_cache(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
         redis_adapter.vacuum(delete_count=1)
 
 
@@ -69,46 +69,46 @@ class TestGetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_client.hset(redis_adapter.hash_name, mapping={'k1': 1})
+        redis_client.hset(redis_adapter.hash_name, mapping={"k1": 1})
 
-        assert redis_adapter.get('k1') == '1'
+        assert redis_adapter.get("k1") == "1"
 
     def test_get_all(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_client.hset(redis_adapter.hash_name, mapping={'k1': 1, 'k2': 2})
+        redis_client.hset(redis_adapter.hash_name, mapping={"k1": 1, "k2": 2})
         result = redis_adapter.get_all()
 
-        assert result == {'k1': '1', 'k2': '2'}
+        assert result == {"k1": "1", "k2": "2"}
 
     def test_get_with_empty_keys(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
         assert redis_adapter.get_all() == {}
 
     @pytest.mark.parametrize(
-        'mapping, keys_to_get, expected',
+        "mapping, keys_to_get, expected",
         [
             pytest.param(
-                {'k1': 1, 'k2': 2},
-                ['k1', 'k2'],
-                {'k1': '1', 'k2': '2'},
-                id='Gets many.',
+                {"k1": 1, "k2": 2},
+                ["k1", "k2"],
+                {"k1": "1", "k2": "2"},
+                id="Gets many.",
             ),
             pytest.param(
-                {'k1': 1},
-                ['k2'],
-                {'k2': None},
-                id='Returns `None` for non-existing keys.',
+                {"k1": 1},
+                ["k2"],
+                {"k2": None},
+                id="Returns `None` for non-existing keys.",
             ),
         ],
     )
@@ -120,7 +120,7 @@ class TestGetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
         redis_client.hset(redis_adapter.hash_name, mapping=mapping)  # type: ignore
 
@@ -131,32 +131,32 @@ class TestGetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_client.hset(redis_adapter.hash_name, mapping={'k': 1})
+        redis_client.hset(redis_adapter.hash_name, mapping={"k": 1})
 
-        assert redis_adapter.get('k') == '1'
+        assert redis_adapter.get("k") == "1"
 
     @pytest.mark.parametrize(
-        'pexpireat, expected',
+        "pexpireat, expected",
         [
             pytest.param(
                 int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp() * 1000)
                 + 9000,
-                '1',
-                id='Now < expireat',
+                "1",
+                id="Now < expireat",
             ),
             pytest.param(
                 int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp() * 1000)
                 + 0,
                 None,
-                id='Now == expireat',
+                id="Now == expireat",
             ),
             pytest.param(
                 int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp() * 1000)
                 - 9000,
                 None,
-                id='Now > expireat',
+                id="Now > expireat",
             ),
         ],
     )
@@ -167,12 +167,12 @@ class TestGetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_client.zadd(name=redis_adapter.zset_name, mapping={'k': pexpireat})
-        redis_client.hset(redis_adapter.hash_name, mapping={'k': 1})
+        redis_client.zadd(name=redis_adapter.zset_name, mapping={"k": pexpireat})
+        redis_client.hset(redis_adapter.hash_name, mapping={"k": 1})
 
-        assert redis_adapter.get('k') == expected
+        assert redis_adapter.get("k") == expected
 
 
 class TestSetScript:
@@ -181,24 +181,24 @@ class TestSetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set(key='key', value='value', ttl=1)
+        redis_adapter.set(key="key", value="value", ttl=1)
 
-        assert redis_client.hgetall(name=redis_adapter.hash_name) == {'key': 'value'}
+        assert redis_client.hgetall(name=redis_adapter.hash_name) == {"key": "value"}
 
     def test_set_many(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many(data=[('k1', 'v1', 1), ('k2', 'v2', 2)])
+        redis_adapter.set_many(data=[("k1", "v1", 1), ("k2", "v2", 2)])
 
         assert redis_client.hgetall(name=redis_adapter.hash_name) == {
-            'k1': 'v1',
-            'k2': 'v2',
+            "k1": "v1",
+            "k2": "v2",
         }
 
     def test_overwrites_the_value_and_ttl(
@@ -206,49 +206,49 @@ class TestSetScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many(data=[('k', 'v', 1)])
+        redis_adapter.set_many(data=[("k", "v", 1)])
         assert redis_client.ttl(redis_adapter.hash_name) == 1
         assert redis_client.ttl(redis_adapter.zset_name) == 1
-        assert redis_client.hgetall(name=redis_adapter.hash_name) == {'k': 'v'}
+        assert redis_client.hgetall(name=redis_adapter.hash_name) == {"k": "v"}
 
-        redis_adapter.set_many(data=[('k', 'v2', 2)])
+        redis_adapter.set_many(data=[("k", "v2", 2)])
         assert redis_client.ttl(redis_adapter.hash_name) == 2
         assert redis_client.ttl(redis_adapter.zset_name) == 2
-        assert redis_client.hgetall(name=redis_adapter.hash_name) == {'k': 'v2'}
+        assert redis_client.hgetall(name=redis_adapter.hash_name) == {"k": "v2"}
 
     def test_expiration(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many(data=[('k', 'v', 1)])
+        redis_adapter.set_many(data=[("k", "v", 1)])
         assert redis_client.ttl(redis_adapter.hash_name) == 1
         assert redis_client.ttl(redis_adapter.zset_name) == 1
 
-        redis_adapter.delete(key='k')
+        redis_adapter.delete(key="k")
 
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
     def test_sets_max_expiration(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many(data=[('k1', 'v1', 3), ('k2', 'v2', 1), ('k3', 'v3', 2)])
+        redis_adapter.set_many(data=[("k1", "v1", 3), ("k2", "v2", 1), ("k3", "v3", 2)])
         assert redis_client.ttl(redis_adapter.hash_name) == 3
         assert redis_client.ttl(redis_adapter.zset_name) == 3
 
-        redis_adapter.set_many(data=[('k4', 'v4', 1)])
+        redis_adapter.set_many(data=[("k4", "v4", 1)])
         assert redis_client.ttl(redis_adapter.hash_name) == 3  # k1 has max expiration
         assert redis_client.ttl(redis_adapter.zset_name) == 3
 
-        redis_adapter.set_many(data=[('k1', 'v1', 0)])
+        redis_adapter.set_many(data=[("k1", "v1", 0)])
         assert redis_client.ttl(redis_adapter.hash_name) == 2  # k3 has max expiration
         assert redis_client.ttl(redis_adapter.zset_name) == 2
 
@@ -259,46 +259,46 @@ class TestDelete:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set(key='key', value='value', ttl=1)
-        assert redis_client.hgetall(redis_adapter.hash_name) == {'key': 'value'}
-        assert redis_adapter.get(key='key') == 'value'
+        redis_adapter.set(key="key", value="value", ttl=1)
+        assert redis_client.hgetall(redis_adapter.hash_name) == {"key": "value"}
+        assert redis_adapter.get(key="key") == "value"
 
-        redis_adapter.delete(key='key')
-        assert redis_adapter.get(key='key') is None
+        redis_adapter.delete(key="key")
+        assert redis_adapter.get(key="key") is None
 
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
     def test_delete_many(
         self,
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many([('k1', 'v1', 1), ('k2', 'v2', 1), ('k3', 'v3', 1)])
+        redis_adapter.set_many([("k1", "v1", 1), ("k2", "v2", 1), ("k3", "v3", 1)])
         assert redis_client.hgetall(redis_adapter.hash_name) == {
-            'k1': 'v1',
-            'k2': 'v2',
-            'k3': 'v3',
+            "k1": "v1",
+            "k2": "v2",
+            "k3": "v3",
         }
-        assert redis_adapter.get_many(keys=['k1', 'k2', 'k3']) == {
-            'k1': 'v1',
-            'k2': 'v2',
-            'k3': 'v3',
-        }
-
-        redis_adapter.delete_many(keys=['k1', 'k2'])
-        assert redis_adapter.get_many(keys=['k1', 'k2', 'k3']) == {
-            'k1': None,
-            'k2': None,
-            'k3': 'v3',
+        assert redis_adapter.get_many(keys=["k1", "k2", "k3"]) == {
+            "k1": "v1",
+            "k2": "v2",
+            "k3": "v3",
         }
 
-        redis_adapter.delete_many(keys=['k3'])
+        redis_adapter.delete_many(keys=["k1", "k2"])
+        assert redis_adapter.get_many(keys=["k1", "k2", "k3"]) == {
+            "k1": None,
+            "k2": None,
+            "k3": "v3",
+        }
 
-        assert not redis_client.keys(pattern='*')
+        redis_adapter.delete_many(keys=["k3"])
+
+        assert not redis_client.keys(pattern="*")
 
 
 class TestDeleteAllScript:
@@ -307,9 +307,9 @@ class TestDeleteAllScript:
         redis_client: redis.Redis,
         redis_adapter: cache_adapter.RedisRepository,
     ):
-        assert not redis_client.keys(pattern='*')
+        assert not redis_client.keys(pattern="*")
 
-        redis_adapter.set_many([('k1', 'v1', 1), ('k2', 'v2', 1), ('k3', 'v3', 1)])
+        redis_adapter.set_many([("k1", "v1", 1), ("k2", "v2", 1), ("k3", "v3", 1)])
         assert (
             redis_client.exists(redis_adapter.hash_name, redis_adapter.zset_name) == 2
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from corva.configuration import SETTINGS
 from corva.testing import TestClient
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def clean_redis():
     redis_client = Redis.from_url(url=SETTINGS.CACHE_URL)
 
@@ -16,6 +16,6 @@ def clean_redis():
     redis_client.flushall()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def context():
     return TestClient._context

--- a/tests/unit/state/test_redis_adapter.py
+++ b/tests/unit/state/test_redis_adapter.py
@@ -9,16 +9,16 @@ from corva.cache_adapter import DeprecatedRedisAdapter
 from corva.configuration import SETTINGS
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def redis_adapter() -> DeprecatedRedisAdapter:
     client = fakeredis.FakeRedis.from_url(url=SETTINGS.CACHE_URL, decode_responses=True)
-    return DeprecatedRedisAdapter(hash_name='default_name', client=client)
+    return DeprecatedRedisAdapter(hash_name="default_name", client=client)
 
 
-NAME = 'NAME'
-KEY = 'key'
-VAL = 'val'
-MAPPING = {'key1': 'val1', 'key2': 'val2'}
+NAME = "NAME"
+KEY = "key"
+VAL = "val"
+MAPPING = {"key1": "val1", "key2": "val2"}
 
 
 def test_connect(redis_adapter):
@@ -26,25 +26,25 @@ def test_connect(redis_adapter):
 
 
 def test_init_connect_exc():
-    fake_cache_url = 'redis://random:123'
+    fake_cache_url = "redis://random:123"
 
     with pytest.raises(ConnectionError):
-        DeprecatedRedisAdapter(hash_name='name', client=Redis.from_url(fake_cache_url))
+        DeprecatedRedisAdapter(hash_name="name", client=Redis.from_url(fake_cache_url))
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_hset_and_hget(redis_adapter, name):
     assert redis_adapter.hset(name=name, key=KEY, value=VAL) == 1
     assert redis_adapter.hget(name=name, key=KEY) == VAL
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_hset_mapping_and_hgetall(redis_adapter, name):
     assert redis_adapter.hset(name=NAME, mapping=MAPPING) == len(MAPPING)
     assert redis_adapter.hgetall(name=NAME) == MAPPING
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_hdel_and_exists(redis_adapter, name):
     def exists():
         if name is None:
@@ -57,7 +57,7 @@ def test_hdel_and_exists(redis_adapter, name):
     assert not exists()
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_delete_and_exists(redis_adapter, name):
     def exists():
         if name is None:
@@ -76,18 +76,18 @@ def test_delete_and_exists(redis_adapter, name):
     assert not exists()
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_ttl(redis_adapter, name):
-    with freeze_time('2020'):
+    with freeze_time("2020"):
         assert redis_adapter.hset(name=name, key=KEY, value=VAL) == 1
         assert (
             redis_adapter.ttl(name=name) == redis_adapter.DEFAULT_EXPIRY.total_seconds()
         )
 
 
-@pytest.mark.parametrize('name', (None, NAME))
+@pytest.mark.parametrize("name", (None, NAME))
 def test_pttl(redis_adapter, name):
-    with freeze_time('2020'):
+    with freeze_time("2020"):
         assert redis_adapter.hset(name=name, key=KEY, value=VAL) == 1
         assert (
             redis_adapter.pttl(name=name)
@@ -96,7 +96,7 @@ def test_pttl(redis_adapter, name):
 
 
 def test_hset_default_expiry(redis_adapter):
-    with freeze_time('2020'):
+    with freeze_time("2020"):
         redis_adapter.hset(key=KEY, value=VAL)
         assert (
             redis_adapter.ttl() == DeprecatedRedisAdapter.DEFAULT_EXPIRY.total_seconds()
@@ -104,14 +104,14 @@ def test_hset_default_expiry(redis_adapter):
 
 
 def test_hset_expiry_override(redis_adapter):
-    with freeze_time('2020'):
+    with freeze_time("2020"):
         for expiry in [10, 5, 20]:
             redis_adapter.hset(key=KEY, value=VAL, expiry=expiry)
             assert redis_adapter.ttl() == expiry
 
 
 def test_hset_expiry_disable(redis_adapter):
-    with freeze_time('2020'):
+    with freeze_time("2020"):
         redis_adapter.hset(key=KEY, value=VAL, expiry=5)
         assert redis_adapter.ttl() == 5
 
@@ -120,7 +120,7 @@ def test_hset_expiry_disable(redis_adapter):
 
 
 def test_hset_expiry(redis_adapter):
-    with freeze_time('2020') as frozen_time:
+    with freeze_time("2020") as frozen_time:
         now = datetime.utcnow()
         redis_adapter.hset(key=KEY, value=VAL, expiry=5)
         frozen_time.move_to(now + timedelta(seconds=5))

--- a/tests/unit/state/test_redis_state.py
+++ b/tests/unit/state/test_redis_state.py
@@ -6,27 +6,27 @@ from corva.configuration import SETTINGS
 from corva.service.cache_sdk import UserRedisSdk
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def redis() -> UserRedisSdk:
     return UserRedisSdk(
-        hash_name='test_hash_name',
+        hash_name="test_hash_name",
         redis_dsn=SETTINGS.CACHE_URL,
         use_fakes=True,
     )
 
 
-KWARGS = {'key1': 'val1'}
-NAMES = ['1', '2']
+KWARGS = {"key1": "val1"}
+NAMES = ["1", "2"]
 
 
 @pytest.mark.parametrize(
-    'call_func_name,mock_func_name',
+    "call_func_name,mock_func_name",
     (
-        ('store', 'hset'),
-        ('load', 'hget'),
-        ('load_all', 'hgetall'),
-        ('ttl', 'ttl'),
-        ('pttl', 'pttl'),
+        ("store", "hset"),
+        ("load", "hget"),
+        ("load_all", "hgetall"),
+        ("ttl", "ttl"),
+        ("pttl", "pttl"),
     ),
 )
 def test_all(redis, call_func_name, mock_func_name):
@@ -37,18 +37,18 @@ def test_all(redis, call_func_name, mock_func_name):
 
 
 def test_delete_all(redis):
-    with patch.object(redis.old_cache_repo, 'delete') as mock_func:
+    with patch.object(redis.old_cache_repo, "delete") as mock_func:
         redis.delete_all(*NAMES)
         mock_func.assert_called_once_with(*NAMES)
 
 
 def test_delete(redis):
-    with patch.object(redis.old_cache_repo, 'hdel') as mock_func:
-        redis.delete(['1'])
-        mock_func.assert_called_once_with(keys=['1'], name=None)
+    with patch.object(redis.old_cache_repo, "hdel") as mock_func:
+        redis.delete(["1"])
+        mock_func.assert_called_once_with(keys=["1"], name=None)
 
 
 def test_exists(redis):
-    with patch.object(redis.old_cache_repo, 'exists') as mock_func:
+    with patch.object(redis.old_cache_repo, "exists") as mock_func:
         redis.exists(*NAMES)
         mock_func.assert_called_once_with(*NAMES)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -17,7 +17,7 @@ def app(event, api):
     return api
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def api(app_runner) -> Api:
     """Returns Api instance from task app."""
 
@@ -29,23 +29,23 @@ def api(app_runner) -> Api:
 def test_request_default_headers(api, requests_mock: RequestsMocker):
     # do some api call
     requests_mock.get(
-        '',
+        "",
         request_headers={
-            'Authorization': f'API {api.api_key}',
-            'X-Corva-App': api.app_key,
+            "Authorization": f"API {api.api_key}",
+            "X-Corva-App": api.app_key,
         },
     )
-    api.get('')
+    api.get("")
 
 
 @pytest.mark.parametrize(
-    'path,expected',
+    "path,expected",
     [
-        ['http://localhost', 'http://localhost'],
-        ['api/v10/path', f'{SETTINGS.DATA_API_ROOT_URL}/api/v10/path'],
-        ['/api/v10/path', f'{SETTINGS.DATA_API_ROOT_URL}/api/v10/path'],
-        ['v10/path', f'{SETTINGS.API_ROOT_URL}/v10/path'],
-        ['/v10/path', f'{SETTINGS.API_ROOT_URL}/v10/path'],
+        ["http://localhost", "http://localhost"],
+        ["api/v10/path", f"{SETTINGS.DATA_API_ROOT_URL}/api/v10/path"],
+        ["/api/v10/path", f"{SETTINGS.DATA_API_ROOT_URL}/api/v10/path"],
+        ["v10/path", f"{SETTINGS.API_ROOT_URL}/v10/path"],
+        ["/v10/path", f"{SETTINGS.API_ROOT_URL}/v10/path"],
     ],
 )
 def test_request_url(path, expected, api, requests_mock: RequestsMocker):
@@ -54,20 +54,20 @@ def test_request_url(path, expected, api, requests_mock: RequestsMocker):
 
 
 def test_request_data_param_passed_as_json(api, requests_mock: RequestsMocker):
-    post_mock = requests_mock.post('')
-    api.post('', data={})
-    assert post_mock.last_request._request.body.decode() == '{}'
+    post_mock = requests_mock.post("")
+    api.post("", data={})
+    assert post_mock.last_request._request.body.decode() == "{}"
 
 
 def test_request_additional_headers(api, requests_mock: RequestsMocker):
-    custom_headers = {'custom': 'value'}
+    custom_headers = {"custom": "value"}
 
-    requests_mock.post('', request_headers={**api.default_headers, **custom_headers})
-    api.post('', headers={'custom': 'value'})
+    requests_mock.post("", request_headers={**api.default_headers, **custom_headers})
+    api.post("", headers={"custom": "value"})
 
 
 @pytest.mark.parametrize(
-    'timeout, exc_ctx',
+    "timeout, exc_ctx",
     [
         (3, contextlib.nullcontext()),
         (30, contextlib.nullcontext()),
@@ -76,22 +76,22 @@ def test_request_additional_headers(api, requests_mock: RequestsMocker):
     ],
 )
 def test_request_timeout_limits(timeout, exc_ctx, api, requests_mock: RequestsMocker):
-    requests_mock.post('')
+    requests_mock.post("")
 
     with exc_ctx:
-        api.post('', timeout=timeout)
+        api.post("", timeout=timeout)
 
 
 @pytest.mark.parametrize(
-    'fields,skip,limit,query,sort',
+    "fields,skip,limit,query,sort",
     (
         [None, 0, 1, {}, {}],
         [
-            '_id',
+            "_id",
             1,
             2,
-            {'k1': 'v1'},
-            {'k2': 'v2'},
+            {"k1": "v1"},
+            {"k2": "v2"},
         ],
     ),
 )
@@ -105,20 +105,20 @@ def test_get_dataset(
     requests_mock: RequestsMocker,
 ):
     provider = SETTINGS.PROVIDER
-    dataset = 'dataset'
+    dataset = "dataset"
 
     qs = urllib.parse.urlencode(
         {
-            'query': json.dumps(query),
-            'sort': json.dumps(sort),
-            **({'fields': fields} if fields else {}),
-            'limit': limit,
-            'skip': skip,
+            "query": json.dumps(query),
+            "sort": json.dumps(sort),
+            **({"fields": fields} if fields else {}),
+            "limit": limit,
+            "skip": skip,
         }
     )
 
     requests_mock.get(
-        f'/api/v1/data/{provider}/{dataset}/?{qs}', complete_qs=True, text='[{}]'
+        f"/api/v1/data/{provider}/{dataset}/?{qs}", complete_qs=True, text="[{}]"
     )
 
     result = api.get_dataset(
@@ -136,10 +136,10 @@ def test_get_dataset(
 
 def test_get_dataset_raises(api, requests_mock: RequestsMocker):
     provider = SETTINGS.PROVIDER
-    dataset = 'dataset'
+    dataset = "dataset"
 
     requests_mock.get(
-        f'/api/v1/data/{provider}/{dataset}/',
+        f"/api/v1/data/{provider}/{dataset}/",
         status_code=400,
     )
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -16,48 +16,48 @@ def task_app(event, api):
 
 
 @pytest.mark.parametrize(
-    'aws_event,aws_context,exc_ctx,expected',
+    "aws_event,aws_context,exc_ctx,expected",
     (
         [
-            RawTaskEvent(task_id='', version=2).dict(),
+            RawTaskEvent(task_id="", version=2).dict(),
             SimpleNamespace(
-                aws_request_id='', client_context=SimpleNamespace(env={'API_KEY': ''})
+                aws_request_id="", client_context=SimpleNamespace(env={"API_KEY": ""})
             ),
             contextlib.nullcontext(),
-            '',
+            "",
         ],
         [
             RawTaskEvent(
-                task_id='', version=2, client_context={'env': {'API_KEY': ''}}
+                task_id="", version=2, client_context={"env": {"API_KEY": ""}}
             ).dict(),
-            SimpleNamespace(aws_request_id='', client_context=None),
+            SimpleNamespace(aws_request_id="", client_context=None),
             contextlib.nullcontext(),
-            '',
+            "",
         ],
         [
             RawTaskEvent(
-                task_id='', version=2, client_context={'env': {'API_KEY': '0'}}
+                task_id="", version=2, client_context={"env": {"API_KEY": "0"}}
             ).dict(),
             SimpleNamespace(
-                aws_request_id='', client_context=SimpleNamespace(env={'API_KEY': '1'})
+                aws_request_id="", client_context=SimpleNamespace(env={"API_KEY": "1"})
             ),
             contextlib.nullcontext(),
-            '1',
+            "1",
         ],
         [
-            RawTaskEvent(task_id='', version=2).dict(),
-            SimpleNamespace(aws_request_id='', client_context=None),
+            RawTaskEvent(task_id="", version=2).dict(),
+            SimpleNamespace(aws_request_id="", client_context=None),
             pytest.raises(pydantic.ValidationError),
-            '',
+            "",
         ],
     ),
     ids=(
-        'Lambda context has not None `client_context`.'
-        'Lambda event has no `client_context`.',
-        'Lambda context has None `client_context`. Lambda event has `client_context`.',
-        'Lambda context has not None `client_context`. '
-        'Lambda event has `client_context`.',
-        'No `client_context` in Lambda context and event.',
+        "Lambda context has not None `client_context`."
+        "Lambda event has no `client_context`.",
+        "Lambda context has None `client_context`. Lambda event has `client_context`.",
+        "Lambda context has not None `client_context`. "
+        "Lambda event has `client_context`.",
+        "No `client_context` in Lambda context and event.",
     ),
 )
 def test_context(

--- a/tests/unit/test_docs/test_api.py
+++ b/tests/unit/test_docs/test_api.py
@@ -19,9 +19,9 @@ from docs.modules.ROOT.examples.api import (
 def test_tutorial001(app_runner, requests_mock: RequestsMocker):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    mock1 = requests_mock.get('/v2/pads')
-    mock2 = requests_mock.get('/api/v1/data/provider/dataset/')
-    mock3 = requests_mock.get('https://api.corva.ai/v2/pads')
+    mock1 = requests_mock.get("/v2/pads")
+    mock2 = requests_mock.get("/api/v1/data/provider/dataset/")
+    mock3 = requests_mock.get("https://api.corva.ai/v2/pads")
 
     app_runner(tutorial001.task_app, event)
 
@@ -31,13 +31,13 @@ def test_tutorial001(app_runner, requests_mock: RequestsMocker):
 
 
 @pytest.mark.parametrize(
-    'json,ctx', ([{}, contextlib.nullcontext()], [None, pytest.raises(JSONDecodeError)])
+    "json,ctx", ([{}, contextlib.nullcontext()], [None, pytest.raises(JSONDecodeError)])
 )
 def test_tutorial002(json, ctx, app_runner, requests_mock: RequestsMocker):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    mock1 = requests_mock.get('/v2/pads', json=json)
-    mock2 = requests_mock.get('/v2/pads?company=1', complete_qs=True)
+    mock1 = requests_mock.get("/v2/pads", json=json)
+    mock2 = requests_mock.get("/v2/pads?company=1", complete_qs=True)
 
     with ctx:
         app_runner(tutorial002.task_app, event)
@@ -49,10 +49,10 @@ def test_tutorial002(json, ctx, app_runner, requests_mock: RequestsMocker):
 def test_tutorial003(app_runner, requests_mock: RequestsMocker):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    post_mock = requests_mock.post('/v2/pads')
-    delete_mock = requests_mock.delete('/v2/pads/123')
-    put_mock = requests_mock.put('/api/v1/data/provider/dataset/')
-    patch_mock = requests_mock.patch('/v2/pads/123')
+    post_mock = requests_mock.post("/v2/pads")
+    delete_mock = requests_mock.delete("/v2/pads/123")
+    put_mock = requests_mock.put("/api/v1/data/provider/dataset/")
+    patch_mock = requests_mock.patch("/v2/pads/123")
 
     app_runner(tutorial003.task_app, event)
 
@@ -66,11 +66,11 @@ def test_tutorial004(app_runner, requests_mock: RequestsMocker):
     event = TaskEvent(asset_id=0, company_id=0)
 
     expected_headers = {
-        'header': 'header-value',
+        "header": "header-value",
         **TestClient._api.default_headers,
     }
 
-    mock = requests_mock.get('/v2/pads')
+    mock = requests_mock.get("/v2/pads")
 
     app_runner(tutorial004.task_app, event)
 
@@ -83,7 +83,7 @@ def test_tutorial004(app_runner, requests_mock: RequestsMocker):
 def test_tutorial005(app_runner, mocker: MockerFixture):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    mock = mocker.patch.object(Api, 'get_dataset')
+    mock = mocker.patch.object(Api, "get_dataset")
 
     app_runner(tutorial005.task_app, event)
 

--- a/tests/unit/test_docs/test_app_types.py
+++ b/tests/unit/test_docs/test_app_types.py
@@ -23,7 +23,7 @@ def test_tutorial001(app_runner):
         asset_id=0, company_id=0, records=[StreamTimeRecord(timestamp=0)]
     )
 
-    assert app_runner(tutorial001.stream_time_app, event) == 'Hello, World!'
+    assert app_runner(tutorial001.stream_time_app, event) == "Hello, World!"
 
 
 def test_tutorial002(app_runner):
@@ -31,19 +31,19 @@ def test_tutorial002(app_runner):
         asset_id=0, company_id=0, records=[StreamDepthRecord(measured_depth=0)]
     )
 
-    assert app_runner(tutorial002.stream_depth_app, event) == 'Hello, World!'
+    assert app_runner(tutorial002.stream_depth_app, event) == "Hello, World!"
 
 
 def test_tutorial003(app_runner):
     event = ScheduledDataTimeEvent(asset_id=0, start_time=0, end_time=0, company_id=0)
 
-    assert app_runner(tutorial003.scheduled_app, event) == 'Hello, World!'
+    assert app_runner(tutorial003.scheduled_app, event) == "Hello, World!"
 
 
 def test_tutorial004(app_runner):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    assert app_runner(tutorial004.task_app, event) == 'Hello, World!'
+    assert app_runner(tutorial004.task_app, event) == "Hello, World!"
 
 
 def test_tutorial005(app_runner):
@@ -52,11 +52,11 @@ def test_tutorial005(app_runner):
         company_id=0,
         top_depth=0.0,
         bottom_depth=1.0,
-        log_identifier='',
+        log_identifier="",
         interval=1.0,
     )
 
-    assert app_runner(tutorial005.scheduled_app, event) == 'Hello, World!'
+    assert app_runner(tutorial005.scheduled_app, event) == "Hello, World!"
 
 
 def test_tutorial006(app_runner):
@@ -64,4 +64,4 @@ def test_tutorial006(app_runner):
         asset_id=0, company_id=0, schedule_start=0, interval=1
     )
 
-    assert app_runner(tutorial006.scheduled_app, event) == 'Hello, World!'
+    assert app_runner(tutorial006.scheduled_app, event) == "Hello, World!"

--- a/tests/unit/test_docs/test_logging.py
+++ b/tests/unit/test_docs/test_logging.py
@@ -10,18 +10,18 @@ from docs.modules.ROOT.examples.logging import tutorial001, tutorial002
 def test_tutorial001(app_runner, mocker: MockerFixture, capsys):
     event = TaskEvent(asset_id=0, company_id=0)
 
-    Logger.setLevel('DEBUG')
+    Logger.setLevel("DEBUG")
 
     # Add handler, as Logger doesnt have one by default
     handler = logging.StreamHandler()
-    handler.setLevel('DEBUG')
-    mocker.patch.object(Logger, 'handlers', [handler])
+    handler.setLevel("DEBUG")
+    mocker.patch.object(Logger, "handlers", [handler])
 
     app_runner(tutorial001.task_app, event)
 
     expected = (
-        'Debug message!\nInfo message!\nWarning message!\n'
-        'Error message!\nException message!\n'
+        "Debug message!\nInfo message!\nWarning message!\n"
+        "Error message!\nException message!\n"
     )
 
     captured = capsys.readouterr().err
@@ -30,20 +30,20 @@ def test_tutorial001(app_runner, mocker: MockerFixture, capsys):
 
 
 def test_tutorial002(context, mocker: MockerFixture, capsys, caplog):
-    raw_event = RawTaskEvent(task_id='0', version=2).dict()
+    raw_event = RawTaskEvent(task_id="0", version=2).dict()
     event = TaskEvent(asset_id=0, company_id=int())
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=event,
     )
-    mocker.patch.object(RawTaskEvent, 'update_task_data')
-    mocker.patch.object(Logger, 'propagate', True)  # for caplog to work
+    mocker.patch.object(RawTaskEvent, "update_task_data")
+    mocker.patch.object(Logger, "propagate", True)  # for caplog to work
 
     tutorial002.task_app(raw_event, context)
 
     captured = capsys.readouterr()
 
-    assert captured.out.endswith('Info message!\n')
-    assert caplog.messages == ['Info message!']
+    assert captured.out.endswith("Info message!\n")
+    assert caplog.messages == ["Info message!"]

--- a/tests/unit/test_docs/test_secrets.py
+++ b/tests/unit/test_docs/test_secrets.py
@@ -6,5 +6,5 @@ def test_tutorial001(app_runner):
     event = TaskEvent(asset_id=0, company_id=0)
 
     app_runner(
-        tutorial001.task_app, event, secrets={'api_token': 'abc12345', 'integer': '1'}
+        tutorial001.task_app, event, secrets={"api_token": "abc12345", "integer": "1"}
     )

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,5 +1,6 @@
 import pytest
 
+from corva.configuration import SETTINGS
 from corva.handlers import scheduled, stream, task
 from corva.models.scheduled.scheduled import (
     ScheduledDataTimeEvent,
@@ -13,6 +14,7 @@ from corva.models.stream.stream import (
     StreamTimeRecord,
 )
 from corva.models.task import TaskEvent
+from corva.service.cache_sdk import UserRedisSdk
 
 
 def test_task_app_runner(app_runner):
@@ -85,3 +87,37 @@ def test_stream_app_runner(event, app_runner):
         return 'Stream app result'
 
     assert app_runner(stream_app, event) == 'Stream app result'
+
+
+def test_reuse_cache(event, app_runner):
+    """
+    Testing that cache is reset or reused between runs.
+    """
+    @scheduled
+    def scheduled_fibonacci(event, api, cache):
+        number1 = int(cache.get('number1') or 1)
+        number2 = int(cache.get('number2') or 1)
+        number3 = number1 + number2
+        cache.set('number1', number2)
+        cache.set('number2', number3)
+
+        return number3
+
+    event = ScheduledDataTimeEvent(
+        asset_id=0, company_id=0,
+        start_time=0, end_time=0
+    )
+
+    # resetting cache - so the results should be the same
+    for _ in range(5):
+        assert app_runner(scheduled_fibonacci, event) == 2
+
+    # reusing cache
+    cache = UserRedisSdk(
+        hash_name='hash_name',
+        redis_dsn=SETTINGS.CACHE_URL,
+        use_fakes=True,
+    )
+    expected_results = [2, 3, 5, 8, 13, 21, 34, 55]
+    for expected_result in expected_results:
+        assert app_runner(scheduled_fibonacci, event, cache=cache) == expected_result

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -93,6 +93,7 @@ def test_reuse_cache(app_runner):
     """
     Testing that cache is reset or reused between runs.
     """
+
     @scheduled
     def scheduled_fibonacci(event, api, cache):
         number1 = int(cache.get('number1') or 1)
@@ -103,10 +104,7 @@ def test_reuse_cache(app_runner):
 
         return number3
 
-    event = ScheduledDataTimeEvent(
-        asset_id=0, company_id=0,
-        start_time=0, end_time=0
-    )
+    event = ScheduledDataTimeEvent(asset_id=0, company_id=0, start_time=0, end_time=0)
 
     # resetting cache - so the results should be the same
     for _ in range(5):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -89,7 +89,7 @@ def test_stream_app_runner(event, app_runner):
     assert app_runner(stream_app, event) == 'Stream app result'
 
 
-def test_reuse_cache(event, app_runner):
+def test_reuse_cache(app_runner):
     """
     Testing that cache is reset or reused between runs.
     """

--- a/tests/unit/test_rerun.py
+++ b/tests/unit/test_rerun.py
@@ -84,7 +84,7 @@ def test_scheduled_depth_app(app_runner):
         company_id=0,
         top_depth=0.0,
         bottom_depth=1.0,
-        log_identifier='',
+        log_identifier="",
         interval=1.0,
         rerun=RerunDepth(range=RerunDepthRange(start=0.0, end=0.0), invoke=0, total=0),
     )

--- a/tests/unit/test_scheduled_app.py
+++ b/tests/unit/test_scheduled_app.py
@@ -48,16 +48,16 @@ def test_set_completed_status(context, requests_mock):
 
     # patch post request, that sets scheduled task as completed
     # looks for url path like /scheduler/123/completed
-    post_mock = requests_mock.post(re.compile(r'/scheduler/\d+/completed'))
+    post_mock = requests_mock.post(re.compile(r"/scheduler/\d+/completed"))
 
     scheduled_app(event, context)
 
     assert post_mock.called_once
-    assert post_mock.last_request.path == '/scheduler/0/completed'
+    assert post_mock.last_request.path == "/scheduler/0/completed"
 
 
 @pytest.mark.parametrize(
-    'event, post_called',
+    "event, post_called",
     [
         pytest.param(
             RawScheduledNaturalTimeEvent(
@@ -71,7 +71,7 @@ def test_set_completed_status(context, requests_mock):
                 interval=int(),
             ),
             True,
-            id='Set status as completed for failed natural time app.',
+            id="Set status as completed for failed natural time app.",
         ),
         pytest.param(
             RawScheduledDataTimeEvent(
@@ -85,7 +85,7 @@ def test_set_completed_status(context, requests_mock):
                 scheduler_type=SchedulerType.data_time,
             ),
             False,
-            id='Does not set status as completed for failed data time app.',
+            id="Does not set status as completed for failed data time app.",
         ),
         pytest.param(
             RawScheduledDepthEvent(
@@ -98,10 +98,10 @@ def test_set_completed_status(context, requests_mock):
                 scheduler_type=SchedulerType.data_depth_milestone,
                 top_depth=0.0,
                 bottom_depth=1.0,
-                log_identifier='',
+                log_identifier="",
             ),
             False,
-            id='Does not set status as completed for failed depth app.',
+            id="Does not set status as completed for failed depth app.",
         ),
     ],
 )
@@ -123,20 +123,20 @@ def test_set_completed_status_for_failed_apps(
 
     # patch post request, that sets scheduled task as completed
     # looks for url path like /scheduler/123/completed
-    post_mock = requests_mock.post(re.compile(r'/scheduler/\d+/completed'))
+    post_mock = requests_mock.post(re.compile(r"/scheduler/\d+/completed"))
 
     with pytest.raises(Exception):
         scheduled_app(app_event, context)
 
     if post_called:
         assert post_mock.called_once
-        assert post_mock.last_request.path == '/scheduler/0/completed'
+        assert post_mock.last_request.path == "/scheduler/0/completed"
     else:
         assert not post_mock.called_once
 
 
 @pytest.mark.parametrize(
-    'event',
+    "event",
     (
         RawScheduledDataTimeEvent(
             asset_id=int(),
@@ -161,7 +161,7 @@ def test_set_completed_status_for_failed_apps(
             scheduler_type=SchedulerType.data_depth_milestone,
             top_depth=0.0,
             bottom_depth=1.0,
-            log_identifier='',
+            log_identifier="",
         ).dict(
             by_alias=True,
             exclude_unset=True,
@@ -181,7 +181,7 @@ def test_set_completed_status_for_failed_apps(
         ),
     ),
 )
-@pytest.mark.parametrize('is_dict', (True, False))
+@pytest.mark.parametrize("is_dict", (True, False))
 def test_event_parsing(event, is_dict, requests_mock: RequestsMocker, context):
     @scheduled
     def scheduled_app(event, api, state):
@@ -196,7 +196,7 @@ def test_event_parsing(event, is_dict, requests_mock: RequestsMocker, context):
 
 
 @pytest.mark.parametrize(
-    'event,attr',
+    "event,attr",
     (
         [
             RawScheduledDataTimeEvent(
@@ -209,7 +209,7 @@ def test_event_parsing(event, is_dict, requests_mock: RequestsMocker, context):
                 company=int(),
                 scheduler_type=SchedulerType.data_time,
             ),
-            'end_time',
+            "end_time",
         ],
         [
             RawScheduledNaturalTimeEvent(
@@ -222,12 +222,12 @@ def test_event_parsing(event, is_dict, requests_mock: RequestsMocker, context):
                 company=int(),
                 scheduler_type=SchedulerType.natural_time,
             ),
-            'schedule_start',
+            "schedule_start",
         ],
     ),
 )
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
         # 31 December 9999 23:59:59 in sec
         [253402300799, 253402300799],
@@ -239,10 +239,10 @@ def test_event_parsing(event, is_dict, requests_mock: RequestsMocker, context):
         [1609459200, 1609459200],
     ),
     ids=(
-        'no cast performed',
-        'casted from ms to sec',
-        'casted from ms to sec',
-        'no cast performed',
+        "no cast performed",
+        "casted from ms to sec",
+        "casted from ms to sec",
+        "no cast performed",
     ),
 )
 def test_set_schedule_start(
@@ -252,7 +252,7 @@ def test_set_schedule_start(
     def app(e, api, state):
         return e
 
-    event = event.copy(update={'schedule_start': value})
+    event = event.copy(update={"schedule_start": value})
     app_event = (
         type(event)
         .parse_obj(
@@ -267,7 +267,7 @@ def test_set_schedule_start(
         )
     )
 
-    mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')
+    mocker.patch.object(RawScheduledEvent, "set_schedule_as_completed")
 
     result_event: ScheduledEvent = app(app_event, context)[0]
 
@@ -275,7 +275,7 @@ def test_set_schedule_start(
 
 
 @pytest.mark.parametrize(
-    'schedule_start,interval,expected',
+    "schedule_start,interval,expected",
     (
         [2, 1, 2],
         [2, 2, 1],
@@ -306,7 +306,7 @@ def test_set_start_time(
         ]
     ]
 
-    mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')
+    mocker.patch.object(RawScheduledEvent, "set_schedule_as_completed")
 
     result_event: ScheduledDataTimeEvent = app(event, context)[0]
 
@@ -337,7 +337,7 @@ def test_set_completed_status_should_not_fail_lambda(context, mocker: MockerFixt
     ]
 
     patch = mocker.patch.object(
-        RawScheduledEvent, 'set_schedule_as_completed', side_effect=Exception
+        RawScheduledEvent, "set_schedule_as_completed", side_effect=Exception
     )
 
     scheduled_app(event, context)
@@ -369,22 +369,22 @@ def test_log_if_unable_to_set_completed_status(context, mocker: MockerFixture, c
     ]
 
     patch = mocker.patch.object(
-        RawScheduledEvent, 'set_schedule_as_completed', side_effect=Exception('Oops!')
+        RawScheduledEvent, "set_schedule_as_completed", side_effect=Exception("Oops!")
     )
 
     scheduled_app(event, context)
 
     captured = capsys.readouterr()
 
-    assert 'ASSET=0 AC=0' in captured.out
-    assert 'Could not set schedule as completed. Details: Oops!.' in captured.out
+    assert "ASSET=0 AC=0" in captured.out
+    assert "Could not set schedule as completed. Details: Oops!." in captured.out
     patch.assert_called_once()
 
 
 def test_custom_log_handler(context, capsys, mocker: MockerFixture):
     @scheduled(handler=logging.StreamHandler())
     def app(event, api, cache):
-        Logger.info('Info message!')
+        Logger.info("Info message!")
 
     event = RawScheduledDataTimeEvent(
         asset_id=0,
@@ -397,7 +397,7 @@ def test_custom_log_handler(context, capsys, mocker: MockerFixture):
         scheduler_type=SchedulerType.data_time,
     )
 
-    mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')
+    mocker.patch.object(RawScheduledEvent, "set_schedule_as_completed")
 
     app(
         [
@@ -413,17 +413,17 @@ def test_custom_log_handler(context, capsys, mocker: MockerFixture):
 
     captured = capsys.readouterr()
 
-    assert captured.out.endswith('Info message!\n')
-    assert captured.err == 'Info message!\n'
+    assert captured.out.endswith("Info message!\n")
+    assert captured.err == "Info message!\n"
 
 
 @pytest.mark.parametrize(
-    'time, expected',
+    "time, expected",
     (
         # 1 January 2021 00:00:00 in ms
-        pytest.param(1609459200000, 1609459200, id='casted from ms to sec'),
+        pytest.param(1609459200000, 1609459200, id="casted from ms to sec"),
         # 1 January 2021 00:00:00 in sec
-        pytest.param(1609459200, 1609459200, id='no cast performed'),
+        pytest.param(1609459200, 1609459200, id="no cast performed"),
     ),
 )
 def test_rerun_data_time_cast_from_ms_to_s(
@@ -447,7 +447,7 @@ def test_rerun_data_time_cast_from_ms_to_s(
         ),
     ).dict(by_alias=True, exclude_unset=True)
 
-    mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')
+    mocker.patch.object(RawScheduledEvent, "set_schedule_as_completed")
 
     result_event: ScheduledDataTimeEvent = app(event, context)[0]
 
@@ -457,12 +457,12 @@ def test_rerun_data_time_cast_from_ms_to_s(
 
 
 @pytest.mark.parametrize(
-    'time, expected',
+    "time, expected",
     (
         # 1 January 2021 00:00:00 in ms
-        pytest.param(1609459200000, 1609459200, id='casted from ms to sec'),
+        pytest.param(1609459200000, 1609459200, id="casted from ms to sec"),
         # 1 January 2021 00:00:00 in sec
-        pytest.param(1609459200, 1609459200, id='no cast performed'),
+        pytest.param(1609459200, 1609459200, id="no cast performed"),
     ),
 )
 def test_rerun_natural_time_cast_from_ms_to_s(
@@ -486,7 +486,7 @@ def test_rerun_natural_time_cast_from_ms_to_s(
         ),
     ).dict(by_alias=True, exclude_unset=True)
 
-    mocker.patch.object(RawScheduledEvent, 'set_schedule_as_completed')
+    mocker.patch.object(RawScheduledEvent, "set_schedule_as_completed")
 
     result_event: ScheduledNaturalTimeEvent = app(event, context)[0]
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -19,7 +19,7 @@ class TestRunApp:
 
         service.run_app(
             has_secrets=False,
-            app_key='',
+            app_key="",
             api_sdk=api_sdk,
             cache_sdk=cache_sdk,
             app=lambda: None,
@@ -35,10 +35,10 @@ class TestRunApp:
             assert secrets == {"name2": "value2"}
 
         api_sdk1 = CachingApiSdk(
-            api_sdk=FakeApiSdk(secrets={'key': {"name1": "value1"}}), ttl=2
+            api_sdk=FakeApiSdk(secrets={"key": {"name1": "value1"}}), ttl=2
         )
         api_sdk2 = CachingApiSdk(
-            api_sdk=FakeApiSdk(secrets={'key': {"name2": "value2"}}), ttl=2
+            api_sdk=FakeApiSdk(secrets={"key": {"name2": "value2"}}), ttl=2
         )
         cache_sdk = FakeInternalCacheSdk()
 
@@ -49,7 +49,7 @@ class TestRunApp:
         with freezegun.freeze_time(freeze_time):
             service.run_app(
                 has_secrets=True,
-                app_key='key',
+                app_key="key",
                 api_sdk=api_sdk1,
                 cache_sdk=cache_sdk,
                 app=app1,
@@ -58,7 +58,7 @@ class TestRunApp:
         with freezegun.freeze_time(freeze_time_plus_1_sec):
             service.run_app(
                 has_secrets=True,
-                app_key='key',
+                app_key="key",
                 api_sdk=api_sdk2,
                 cache_sdk=cache_sdk,
                 app=app1,
@@ -67,20 +67,20 @@ class TestRunApp:
         with freezegun.freeze_time(freeze_time_plus_2_sec):
             service.run_app(
                 has_secrets=True,
-                app_key='key',
+                app_key="key",
                 api_sdk=api_sdk2,
                 cache_sdk=cache_sdk,
                 app=app2,
             )
 
     @pytest.mark.parametrize(
-        'has_secrets, expected_secrets',
+        "has_secrets, expected_secrets",
         (
             pytest.param(
-                False, {}, id='Does not fetch secrets if `has_secrets is False`'
+                False, {}, id="Does not fetch secrets if `has_secrets is False`"
             ),
             pytest.param(
-                True, {'my': 'secret'}, id='Fetches secrets if `has_secrets is True`'
+                True, {"my": "secret"}, id="Fetches secrets if `has_secrets is True`"
             ),
         ),
     )
@@ -92,12 +92,12 @@ class TestRunApp:
 
         assert secrets == {}
 
-        api_sdk = FakeApiSdk(secrets={'test_app_key': {"my": "secret"}})
+        api_sdk = FakeApiSdk(secrets={"test_app_key": {"my": "secret"}})
         cache_sdk = FakeInternalCacheSdk()
 
         service.run_app(
             has_secrets=has_secrets,
-            app_key='test_app_key',
+            app_key="test_app_key",
             api_sdk=api_sdk,
             cache_sdk=cache_sdk,
             app=app,
@@ -111,7 +111,7 @@ class TestRunApp:
 
         result = service.run_app(
             has_secrets=False,
-            app_key='',
+            app_key="",
             api_sdk=api_sdk,
             cache_sdk=cache_sdk,
             app=lambda: 10,

--- a/tests/unit/test_stream_app.py
+++ b/tests/unit/test_stream_app.py
@@ -20,8 +20,8 @@ from corva.models.stream.raw import (
 from corva.models.stream.stream import StreamEvent, StreamTimeEvent
 
 
-@pytest.mark.parametrize('attr', ('asset_id', 'company_id'))
-@pytest.mark.parametrize('value', (1, 2))
+@pytest.mark.parametrize("attr", ("asset_id", "company_id"))
+@pytest.mark.parametrize("value", (1, 2))
 def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixture):
     @stream
     def stream_app(event, api, cache):
@@ -33,7 +33,7 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
                 RawTimeRecord(
                     collection=str(),
                     timestamp=int(),
-                    **{'asset_id': int(), 'company_id': int(), **{attr: value}},
+                    **{"asset_id": int(), "company_id": int(), **{attr: value}},
                 )
             ],
             metadata=RawMetadata(
@@ -50,7 +50,7 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
 
 
 @pytest.mark.parametrize(
-    'last_value,event,expected',
+    "last_value,event,expected",
     [
         (
             -1,
@@ -66,7 +66,7 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
                         RawTimeRecord(
                             asset_id=int(),
                             company_id=int(),
-                            collection='wits.completed',
+                            collection="wits.completed",
                             timestamp=int(),
                         ),
                     ],
@@ -96,7 +96,7 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
                         RawTimeRecord(
                             asset_id=int(),
                             company_id=int(),
-                            collection='wits.completed',
+                            collection="wits.completed",
                             timestamp=int(),
                         ),
                         RawTimeRecord(
@@ -119,7 +119,7 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
                 RawTimeRecord(
                     asset_id=int(),
                     company_id=int(),
-                    collection='wits.completed',
+                    collection="wits.completed",
                     timestamp=int(),
                 ),
                 RawTimeRecord(
@@ -246,11 +246,11 @@ def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixtur
         ),
     ],
     ids=[
-        'is completed record last - should be filtered',
-        'is completed record not last - should not be filtered',
-        'last value is None - filtering doesnt fail',
-        'time event filtered',
-        'depth event filtered',
+        "is completed record last - should be filtered",
+        "is completed record not last - should not be filtered",
+        "last value is None - filtering doesnt fail",
+        "time event filtered",
+        "depth event filtered",
     ],
 )
 def test_filter_records(last_value, event, expected, mocker: MockerFixture, context):
@@ -258,9 +258,9 @@ def test_filter_records(last_value, event, expected, mocker: MockerFixture, cont
     def stream_app(event, api, cache):
         pass
 
-    spy = mocker.spy(RawStreamEvent, 'filter_records')
+    spy = mocker.spy(RawStreamEvent, "filter_records")
     mocker.patch.object(
-        RawStreamEvent, 'get_cached_max_record_value', return_value=last_value
+        RawStreamEvent, "get_cached_max_record_value", return_value=last_value
     )
 
     stream_app(event, context)
@@ -292,7 +292,7 @@ def test_early_return_if_no_records_after_filtering(mocker: MockerFixture, conte
     ]
 
     filter_patch = mocker.patch.object(
-        RawStreamEvent, 'filter_records', return_value=[]
+        RawStreamEvent, "filter_records", return_value=[]
     )
     spy = mocker.Mock(stream_app, wraps=stream_app)
 
@@ -303,7 +303,7 @@ def test_early_return_if_no_records_after_filtering(mocker: MockerFixture, conte
 
 
 @pytest.mark.parametrize(
-    'expected,event',
+    "expected,event",
     [
         (
             1,
@@ -438,7 +438,7 @@ def test_last_processed_value_saved_to_cache(
     def stream_app(event, api, cache):
         pass
 
-    spy = mocker.spy(RawStreamEvent, 'get_cached_max_record_value')
+    spy = mocker.spy(RawStreamEvent, "get_cached_max_record_value")
     stream_app(event * 2, context)
 
     assert spy.call_count == 2
@@ -471,7 +471,7 @@ def test_set_cached_max_record_value_should_not_fail_lambda(
     ]
 
     patch = mocker.patch.object(
-        RawStreamEvent, 'set_cached_max_record_value', side_effect=Exception
+        RawStreamEvent, "set_cached_max_record_value", side_effect=Exception
     )
 
     stream_app(event, context)
@@ -505,22 +505,22 @@ def test_log_if_unable_to_set_cached_max_record_value(
     ]
 
     patch = mocker.patch.object(
-        RawStreamEvent, 'set_cached_max_record_value', side_effect=Exception('Oops!')
+        RawStreamEvent, "set_cached_max_record_value", side_effect=Exception("Oops!")
     )
 
     stream_app(event, context)
 
     captured = capsys.readouterr()
 
-    assert 'ASSET=0 AC=0' in captured.out
-    assert 'Could not save data to cache. Details: Oops!.' in captured.out
+    assert "ASSET=0 AC=0" in captured.out
+    assert "Could not save data to cache. Details: Oops!." in captured.out
     patch.assert_called_once()
 
 
 def test_custom_log_handler(context, capsys):
     @stream(handler=logging.StreamHandler())
     def app(event, api, cache):
-        Logger.info('Info message!')
+        Logger.info("Info message!")
 
     event = RawStreamTimeEvent(
         records=[
@@ -542,17 +542,17 @@ def test_custom_log_handler(context, capsys):
 
     captured = capsys.readouterr()
 
-    assert captured.out.endswith('Info message!\n')
-    assert captured.err == 'Info message!\n'
+    assert captured.out.endswith("Info message!\n")
+    assert captured.err == "Info message!\n"
 
 
 @pytest.mark.parametrize(
-    'time, expected',
+    "time, expected",
     (
         # 1 January 2021 00:00:00 in ms
-        pytest.param(1609459200000, 1609459200, id='casted from ms to sec'),
+        pytest.param(1609459200000, 1609459200, id="casted from ms to sec"),
         # 1 January 2021 00:00:00 in sec
-        pytest.param(1609459200, 1609459200, id='no cast performed'),
+        pytest.param(1609459200, 1609459200, id="no cast performed"),
     ),
 )
 def test_rerun_time_cast_from_ms_to_s(time: int, expected: int, context):

--- a/tests/unit/test_task_app.py
+++ b/tests/unit/test_task_app.py
@@ -11,13 +11,13 @@ from corva.models.task import RawTaskEvent, TaskEvent
 
 
 @pytest.mark.parametrize(
-    'status_code,json,status',
+    "status_code,json,status",
     (
-        [400, None, 'fail'],
+        [400, None, "fail"],
         [
             200,
             TaskEvent(asset_id=int(), company_id=int()).dict(),
-            'success',
+            "success",
         ],
     ),
 )
@@ -32,30 +32,30 @@ def test_lambda_succeeds_if_unable_to_get_task_event(
     def task_app(event, api):
         return True
 
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     get_mock = requests_mock.get(
-        re.compile('/v2/tasks/0'), status_code=status_code, json=json
+        re.compile("/v2/tasks/0"), status_code=status_code, json=json
     )
-    put_mock = requests_mock.put(re.compile(f'/v2/tasks/0/{status}'))
+    put_mock = requests_mock.put(re.compile(f"/v2/tasks/0/{status}"))
 
     result = task_app(event, context)[0]
 
     assert get_mock.called_once
     assert put_mock.called_once
 
-    if status == 'fail':
-        assert set(put_mock.request_history[0].json()) == {'fail_reason'}
+    if status == "fail":
+        assert set(put_mock.request_history[0].json()) == {"fail_reason"}
         assert result is None
 
-    if status == 'success':
-        assert put_mock.request_history[0].json() == {'payload': {}}
+    if status == "success":
+        assert put_mock.request_history[0].json() == {"payload": {}}
         assert result is True
 
 
 @pytest.mark.parametrize(
-    'status,side_effect',
-    (['fail', Exception('test_user_app_raises')], ['success', None]),
+    "status,side_effect",
+    (["fail", Exception("test_user_app_raises")], ["success", None]),
 )
 def test_lambda_succeeds_if_user_app_fails(
     status,
@@ -64,14 +64,14 @@ def test_lambda_succeeds_if_user_app_fails(
     mocker: MockerFixture,
     requests_mock: RequestsMocker,
 ):
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=TaskEvent(asset_id=int(), company_id=int()),
     )
-    put_mock = requests_mock.put(re.compile(f'/v2/tasks/0/{status}'))
+    put_mock = requests_mock.put(re.compile(f"/v2/tasks/0/{status}"))
 
     result = task(mocker.Mock(side_effect=side_effect, return_value=True))(
         event, context
@@ -79,14 +79,14 @@ def test_lambda_succeeds_if_user_app_fails(
 
     assert put_mock.called_once
 
-    if status == 'fail':
+    if status == "fail":
         assert put_mock.request_history[0].json() == {
-            'fail_reason': 'test_user_app_raises'
+            "fail_reason": "test_user_app_raises"
         }
         assert result is None
 
-    if status == 'success':
-        assert put_mock.request_history[0].json() == {'payload': {}}
+    if status == "success":
+        assert put_mock.request_history[0].json() == {"payload": {}}
         assert result is True
 
 
@@ -95,16 +95,16 @@ def test_lambda_succeeds_if_unable_to_update_task_data(context, mocker: MockerFi
     def task_app(event, api):
         return True
 
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=TaskEvent(asset_id=int(), company_id=int()),
     )
     update_task_data_patch = mocker.patch.object(
         RawTaskEvent,
-        'update_task_data',
+        "update_task_data",
         side_effect=Exception,
     )
 
@@ -114,17 +114,17 @@ def test_lambda_succeeds_if_unable_to_update_task_data(context, mocker: MockerFi
 
 
 @pytest.mark.parametrize(
-    'app_result, expected_payload',
+    "app_result, expected_payload",
     [
         pytest.param(
             True,
             {},
-            id='Task handler doesnt store non-dict data in task payload.',
+            id="Task handler doesnt store non-dict data in task payload.",
         ),
         pytest.param(
-            {'field': 'value'},
-            {'field': 'value'},
-            id='Task handler stores dict data in task payload.',
+            {"field": "value"},
+            {"field": "value"},
+            id="Task handler stores dict data in task payload.",
         ),
     ],
 )
@@ -135,20 +135,20 @@ def test_task_app_succeeds(
     def task_app(event, api):
         return app_result
 
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     get_mock = requests_mock.get(
-        re.compile('/v2/tasks/0'),
+        re.compile("/v2/tasks/0"),
         json=TaskEvent(asset_id=int(), company_id=int()).dict(),
     )
-    put_mock = requests_mock.put(re.compile('/v2/tasks/0/success'))
+    put_mock = requests_mock.put(re.compile("/v2/tasks/0/success"))
 
     result = task_app(event, context)[0]
 
     assert get_mock.called_once
     assert put_mock.called_once
 
-    assert put_mock.request_history[0].json()['payload'] == expected_payload
+    assert put_mock.request_history[0].json()["payload"] == expected_payload
     assert result == app_result
 
 
@@ -157,25 +157,25 @@ def test_log_if_unable_to_update_task_data(context, mocker: MockerFixture, capsy
     def task_app(event, api):
         return True
 
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=TaskEvent(asset_id=int(), company_id=int()),
     )
     update_task_data_patch = mocker.patch.object(
         RawTaskEvent,
-        'update_task_data',
-        side_effect=Exception('Oops!'),
+        "update_task_data",
+        side_effect=Exception("Oops!"),
     )
 
     task_app(event, context)
 
     captured = capsys.readouterr()
 
-    assert 'ASSET=0' in captured.out
-    assert 'Could not update task data. Details: Oops!.' in captured.out
+    assert "ASSET=0" in captured.out
+    assert "Could not update task data. Details: Oops!." in captured.out
     update_task_data_patch.assert_called_once()
 
 
@@ -185,42 +185,42 @@ def test_log_if_user_app_fails(
     requests_mock: RequestsMocker,
     capsys,
 ):
-    event = RawTaskEvent(task_id='0', version=2).dict()
+    event = RawTaskEvent(task_id="0", version=2).dict()
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=TaskEvent(asset_id=int(), company_id=int()),
     )
-    put_mock = requests_mock.put(re.compile('/v2/tasks/0/fail'))
+    put_mock = requests_mock.put(re.compile("/v2/tasks/0/fail"))
 
     task(mocker.Mock(side_effect=Exception))(event, context)
 
     captured = capsys.readouterr()
 
     assert put_mock.called_once
-    assert 'ASSET=0' in captured.out
-    assert 'Task app failed to execute.' in captured.out
+    assert "ASSET=0" in captured.out
+    assert "Task app failed to execute." in captured.out
 
 
 def test_custom_log_handler(context, mocker: MockerFixture, capsys):
     @task(handler=logging.StreamHandler())
     def app(event, api):
-        Logger.info('Info message!')
+        Logger.info("Info message!")
 
-    raw_event = RawTaskEvent(task_id='0', version=2).dict()
+    raw_event = RawTaskEvent(task_id="0", version=2).dict()
     event = TaskEvent(asset_id=0, company_id=int())
 
     mocker.patch.object(
         RawTaskEvent,
-        'get_task_event',
+        "get_task_event",
         return_value=event,
     )
-    mocker.patch.object(RawTaskEvent, 'update_task_data')
+    mocker.patch.object(RawTaskEvent, "update_task_data")
 
     app(raw_event, context)
 
     captured = capsys.readouterr()
 
-    assert captured.out.endswith('Info message!\n')
-    assert captured.err == 'Info message!\n'
+    assert captured.out.endswith("Info message!\n")
+    assert captured.err == "Info message!\n"


### PR DESCRIPTION
### Rationale
For integrated testing of scheduled or stream apps, we are relying on the cache to be reused. However, the `app_runner` does not provide handlers to support this functionality. I'm suggesting adding a `kwarg` in the `app_runner` to support this.

### Changes
- Added a `kwarg` to `app_runner` plugin
- Added a test case for this feature

#### TODO
- [ ] Update CHANGELOG.md
