### PR TITLE
Added the functionality to reuse cache in app_runner

### DIFF
--- a/src/corva/testing.py
+++ b/src/corva/testing.py
@@ -36,7 +36,8 @@ class TestClient:
         fn: Callable,
         event: Union[TaskEvent, StreamEvent, ScheduledEvent],
         *,
-        secrets: Optional[Dict[str, str]] = None
+        secrets: Optional[Dict[str, str]] = None,
+        cache: UserRedisSdk = None
     ) -> Any:
 
         app: Callable[[], Any]
@@ -45,15 +46,18 @@ class TestClient:
             app = functools.partial(inspect.unwrap(fn), event, TestClient._api)
 
         if isinstance(event, (ScheduledEvent, StreamEvent)):
+            if not cache:
+                cache = UserRedisSdk(
+                    hash_name="hash_name",
+                    redis_dsn=SETTINGS.CACHE_URL,
+                    use_fakes=True,
+                )
+
             app = functools.partial(
                 inspect.unwrap(fn),
                 event,
                 TestClient._api,
-                UserRedisSdk(
-                    hash_name='hash_name',
-                    redis_dsn=SETTINGS.CACHE_URL,
-                    use_fakes=True,
-                ),
+                cache,
             )
 
         return service.run_app(

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,5 +1,6 @@
 import pytest
 
+from corva.configuration import SETTINGS
 from corva.handlers import scheduled, stream, task
 from corva.models.scheduled.scheduled import (
     ScheduledDataTimeEvent,
@@ -13,6 +14,7 @@ from corva.models.stream.stream import (
     StreamTimeRecord,
 )
 from corva.models.task import TaskEvent
+from corva.service.cache_sdk import UserRedisSdk
 
 
 def test_task_app_runner(app_runner):
@@ -85,3 +87,35 @@ def test_stream_app_runner(event, app_runner):
         return 'Stream app result'
 
     assert app_runner(stream_app, event) == 'Stream app result'
+
+
+def test_reuse_cache(app_runner):
+    """
+    Testing that cache is reset or reused between runs.
+    """
+
+    @scheduled
+    def scheduled_fibonacci(event, api, cache):
+        number1 = int(cache.get('number1') or 1)
+        number2 = int(cache.get('number2') or 1)
+        number3 = number1 + number2
+        cache.set('number1', number2)
+        cache.set('number2', number3)
+
+        return number3
+
+    event = ScheduledDataTimeEvent(asset_id=0, company_id=0, start_time=0, end_time=0)
+
+    # resetting cache - so the results should be the same
+    for _ in range(5):
+        assert app_runner(scheduled_fibonacci, event) == 2
+
+    # reusing cache
+    cache = UserRedisSdk(
+        hash_name='hash_name',
+        redis_dsn=SETTINGS.CACHE_URL,
+        use_fakes=True,
+    )
+    expected_results = [2, 3, 5, 8, 13, 21, 34, 55]
+    for expected_result in expected_results:
+        assert app_runner(scheduled_fibonacci, event, cache=cache) == expected_result


### PR DESCRIPTION
### Rationale
For integrated testing of scheduled or stream apps, we are relying on the cache to be reused. However, the `app_runner` does not provide handlers to support this functionality. I'm suggesting adding a `kwarg` in the `app_runner` to support this.

### Changes
- Added a `kwarg` to `app_runner` plugin
- Added a test case for this feature

#### TODO
- [ ] Update CHANGELOG.md
