### PR TITLE
DC-4313 `Api.produce_messages` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `produce_messages` method to `Api`.
+See corresponding section in docs.
+
 
 ## [1.6.0] - 2022-10-19
 
-### Changed
-- Added `cache` parameter to `app_runner` to reuse the cache object.
+### Added
+- `cache` parameter to `app_runner`
+to reuse the cache object.
 
 
 ## [1.5.3] - 2022-09-05

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,11 @@ clean:
 release:
 	@echo "Checkout the master branch."
 	@echo "Update src/version.py with new version."
-	@echo "Update docs/antora.yml with new version."
+	@echo "Update docs/antora.yml 'version' with new version like '1.6.0'."
 	@echo "Update docs/antora-playbook.yml 'content.sources.tags'."
 	@echo "Update CHANGELOG.md."
 	@echo "Commit the changes."
-	@echo "Create tag like "v1.0.0"."
+	@echo "Create tag like 'v1.6.0'."
 	@echo "Nullify version in docs/antora.yml."
 	@echo "Commit the changes."
 	@echo "Push commits and tag."

--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,12 @@ clean:
 release:
 	@echo "Checkout the master branch."
 	@echo "Update src/version.py with new version."
-	@echo "Update `docs/antora.yml` with new version."
-	@echo "Update `docs/antora-playbook.yml` `content.sources.tags`."
+	@echo "Update docs/antora.yml with new version."
+	@echo "Update docs/antora-playbook.yml 'content.sources.tags'."
 	@echo "Update CHANGELOG.md."
 	@echo "Commit the changes."
 	@echo "Create tag like "v1.0.0"."
-	@echo "Nullify version in `docs/antora.yml`."
+	@echo "Nullify version in docs/antora.yml."
 	@echo "Commit the changes."
 	@echo "Push commits and tag."
 

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -5,8 +5,8 @@ content:
   sources:
     - url: /antora  # Volume mount target inside docker container
       start_path: docs
-      # Use `branches: HEAD` for local development
       branches: []
+#      branches: HEAD  # Use this for local development
       tags: [v1.6.0]
 asciidoc:
   attributes:

--- a/docs/modules/ROOT/examples/api/tutorial006.py
+++ b/docs/modules/ROOT/examples/api/tutorial006.py
@@ -1,0 +1,11 @@
+from corva import Api, Cache, ScheduledDataTimeEvent, ScheduledDepthEvent, scheduled
+
+
+@scheduled
+def scheduled_time_app(event: ScheduledDataTimeEvent, api: Api, cache: Cache):
+    api.produce_messages(data=[{'timestamp': 1}, {'timestamp': 2}])  # <.>
+
+
+@scheduled
+def scheduled_depth_app(event: ScheduledDepthEvent, api: Api, cache: Cache):
+    api.produce_messages(data=[{'measured_depth': 1.0}, {'measured_depth': 2.0}])  # <.>

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,6 +4,7 @@
 :corva-platform-api-link: https://api.corva.ai/documentation/index.html[Corva Platform API]
 :corva-data-api-link: https://data.corva.ai/docs#/[Corva Data API]
 :api-v1-data-provider-dataset-link: https://data.corva.ai/docs#/default/index_api_v1_data__provider___dataset___get[/api/v1/data/provider/dataset/]
+:api-v1-message-producer-link: https://data.qa.corva.ai/docs#/data/produce_api_v1_message_producer__post[/api/v1/message_producer/]
 :python-log-levels-link: https://docs.python.org/3/howto/logging.html[Python log levels]
 :python-log-handlers-link: https://docs.python.org/3/howto/logging.html#handlers
 :pytest-plugin-link: https://docs.pytest.org/en/stable/writing_plugins.html[pytest-plugin]
@@ -219,6 +220,21 @@ using `Api.get_dataset` method.
 ----
 include::example$api/tutorial005.py[]
 ----
+
+==== Produce messages
+
+Post data to the {api-v1-message-producer-link} endpoint
+using `Api.produce_messages` method.
+The method will work for both
+<<stream,`stream`>>
+and <<scheduled,`scheduled`>> types of apps.
+
+[source,python]
+----
+include::example$api/tutorial006.py[]
+----
+<.> Example of producing time messages.
+<.> Example of producing depth messages.
 
 [#cache]
 == Cache

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -221,6 +221,7 @@ using `Api.get_dataset` method.
 include::example$api/tutorial005.py[]
 ----
 
+[#produce_messages]
 ==== Produce messages
 
 Post data to the {api-v1-message-producer-link} endpoint
@@ -491,6 +492,14 @@ and pass corresponding logging handler
 as a keyword argument to the app decorator.
 Use code samples above as the examples.
 
+== Followable apps
+
+Followable apps must produce
+messages in order to trigger
+chain reaction of app runs.
+See <<produce_messages>> section
+for instructions on how to produce
+messages.
 
 == Secrets
 You can store sensitive data such as passwords,

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ parallel = True
 
 [coverage:report]
 precision = 2
-fail_under = 98.07
+fail_under = 98.01
 skip_covered = True
 show_missing = True
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ parallel = True
 
 [coverage:report]
 precision = 2
-fail_under = 98.01
+fail_under = 98.03
 skip_covered = True
 show_missing = True
 exclude_lines =

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -23,11 +23,13 @@ class Api:
         api_key: str,
         app_key: str,
         timeout: Optional[int] = None,
+        app_connection_id: Optional[int] = None,
     ):
         self.api_url = api_url
         self.data_api_url = data_api_url
         self.api_key = api_key
         self.app_key = app_key
+        self.app_connection_id = app_connection_id
         self.timeout = timeout or self.TIMEOUT_LIMITS[1]
 
     @property
@@ -178,3 +180,22 @@ class Api:
         data = list(response.json())
 
         return data
+
+    def produce_messages(self, data: List[dict]) -> None:
+        """Posts data to the endpoint '/api/v1/message_producer/'.
+
+        Args:
+          data: messages to post.
+            Message examples:
+            - time message [{"timestamp": 1}];
+            - depth message [{"measured_depth": 1.0}].
+
+        Raises:
+          requests.HTTPError: if request was unsuccessful.
+        """
+
+        response = self.post(
+            '/api/v1/message_producer/',
+            json={'app_connection_id': self.app_connection_id, 'data': data},
+        )
+        response.raise_for_status()

--- a/tests/unit/test_docs/test_api.py
+++ b/tests/unit/test_docs/test_api.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 from requests_mock import Mocker as RequestsMocker
 
-from corva import Api, TaskEvent
+from corva import Api, ScheduledDataTimeEvent, ScheduledDepthEvent, TaskEvent
 from corva.testing import TestClient
 from docs.modules.ROOT.examples.api import (
     tutorial001,
@@ -13,6 +13,7 @@ from docs.modules.ROOT.examples.api import (
     tutorial003,
     tutorial004,
     tutorial005,
+    tutorial006,
 )
 
 
@@ -88,3 +89,24 @@ def test_tutorial005(app_runner, mocker: MockerFixture):
     app_runner(tutorial005.task_app, event)
 
     mock.assert_called_once()
+
+
+def test_tutorial006(app_runner, mocker: MockerFixture):
+    time_event = ScheduledDataTimeEvent(
+        asset_id=0, company_id=0, start_time=0, end_time=0
+    )
+    time_mock = mocker.patch.object(Api, 'produce_messages')
+    app_runner(tutorial006.scheduled_time_app, time_event)
+    time_mock.assert_called_once()
+
+    depth_event = ScheduledDepthEvent(
+        asset_id=0,
+        company_id=0,
+        top_depth=0,
+        bottom_depth=0,
+        log_identifier='',
+        interval=0,
+    )
+    depth_mock = mocker.patch.object(Api, 'produce_messages')
+    app_runner(tutorial006.scheduled_depth_app, depth_event)
+    depth_mock.assert_called_once()


### PR DESCRIPTION
### Rationale
Users should be able to post messages to message producer in `stream` and `scheduled` apps.

### Changes
Added `produce_messages` method to `Api`


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-4313)

#### TODO
- [X] Update CHANGELOG.md
