### PR TITLE
DC-4784 Add `id` field to rerun data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `id` field to rerun data.
+
 
 ## [1.8.0] - 2022-11-28
 

--- a/src/corva/models/rerun.py
+++ b/src/corva/models/rerun.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pydantic
 
 from corva.models import base, validators
@@ -35,11 +37,13 @@ class RerunTime(base.CorvaBaseEvent):
     """Rerun metadata for time event.
 
     Attributes:
+        id: rerun id.
         range: rerun time range.
         invoke: invoke counter.
         total: total invoke count for the rerun.
     """
 
+    id: Optional[int]  # TODO: remove optional in v2, it was added for backward comp
     range: RerunTimeRange
     invoke: int
     total: int
@@ -49,11 +53,13 @@ class RerunDepth(base.CorvaBaseEvent):
     """Rerun metadata for depth event.
 
     Attributes:
+        id: rerun id.
         range: rerun depth range.
         invoke: invoke counter.
         total: total invoke count for the rerun.
     """
 
+    id: Optional[int]  # TODO: remove optional in v2, it was added for backward comp
     range: RerunDepthRange
     invoke: int
     total: int


### PR DESCRIPTION
### Rationale
Users need to know `id` of rerun.

### Changes
Added `id` field to rerun data.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-4784)

#### TODO
- [X] Update CHANGELOG.md
