### PR TITLE
DC-5036 Add `log_identifier` field to stream depth events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `log_identifier` field to stream depth events.
 
-### Changed
-- Reraise exceptions in `task` apps
-instead of suppressing them.
-
 
 ## [1.8.1] - 2023-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `log_identifier` field to stream depth events.
+
+### Changed
+- Reraise exceptions in `task` apps
+instead of suppressing them.
+
 
 ## [1.8.1] - 2023-01-24
 

--- a/src/corva/models/stream/raw.py
+++ b/src/corva/models/stream/raw.py
@@ -63,6 +63,8 @@ class RawMetadata(CorvaBaseEvent):
         },
     )
     log_type: LogType
+    # TODO: remove `Optional` in v2 as it was added for backward compatibility.
+    log_identifier: Optional[str] = None
 
 
 if TYPE_CHECKING:
@@ -190,3 +192,14 @@ class RawStreamDepthEvent(RawStreamEvent):
     records: RecordsDepth
     rerun: Optional[RerunDepth] = None
     _max_record_value_cache_key: ClassVar[str] = 'last_processed_depth'
+    log_identifier: str = None  # type: ignore
+
+    @pydantic.root_validator(pre=False, skip_on_failure=True)
+    def set_log_identifier(cls, values: dict) -> dict:
+        """Calculates log_identifier field."""
+
+        metadata: RawMetadata = values["metadata"]
+
+        values["log_identifier"] = metadata.log_identifier
+
+        return values

--- a/src/corva/models/stream/stream.py
+++ b/src/corva/models/stream/stream.py
@@ -75,4 +75,6 @@ class StreamDepthEvent(StreamEvent):
     asset_id: int
     company_id: int
     records: RecordsDepth
+    # TODO: remove `Optional` in v2 as it was added for backward compatibility.
+    log_identifier: Optional[str] = None
     rerun: Optional[RerunDepth] = None

--- a/tests/unit/test_stream_app.py
+++ b/tests/unit/test_stream_app.py
@@ -22,7 +22,7 @@ from corva.models.stream.stream import StreamDepthEvent, StreamEvent, StreamTime
 
 @pytest.mark.parametrize('attr', ('asset_id', 'company_id'))
 @pytest.mark.parametrize('value', (1, 2))
-def test_set_attr_in_raw_stream_event(attr, value, context, mocker: MockerFixture):
+def test_set_attr_in_raw_stream_event(attr, value, context):
     @stream
     def stream_app(event, api, cache):
         return event


### PR DESCRIPTION
### Rationale
Stream depth events must have `log_identifier` field.

### Changes
Added `log_identifier` field to stream depth events.


[JIRA ticket](https://corvaqa.atlassian.net/browse/DC-5036)

#### TODO
- [X] Update CHANGELOG.md
