### PR TITLE
Fix `urllib3` v2 not supported by AWS Lambda.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `urllib3` v2 not supported by AWS Lambda.
+
 
 ## [1.9.0] - 2023-03-06
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "pydantic >=1.8.2, <2.0.0",
         "redis >=3.5.3, <4.0.0",
         "requests >=2.25.0, <3.0.0",
-        "urllib3 <2"  # lambda doesnt support version 2 yet
+        "urllib3 <2",  # lambda doesnt support version 2 yet
     ],
     python_requires='>=3.8, <4.0',
     license='The Unlicense',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "pydantic >=1.8.2, <2.0.0",
         "redis >=3.5.3, <4.0.0",
         "requests >=2.25.0, <3.0.0",
+        "urllib3 <2"  # lambda doesnt support version 2 yet
     ],
     python_requires='>=3.8, <4.0',
     license='The Unlicense',


### PR DESCRIPTION
### Rationale
`urllib3` v2 not supported by AWS Lambda.

### Changes
Pinned `urllib3` version to be lower than 2.


[JIRA ticket](put the link to the corresponding JIRA ticket here)

#### TODO
- [X] Update CHANGELOG.md
