### PR TITLE
Fixing exceptions on documents inserts

### DIFF
--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -232,7 +232,7 @@ class Api:
         else:
             body = list(data)
 
-        response = self.post(f'/api/v1/data/{provider}/{dataset}/', json=body)
+        response = self.post(f'/api/v1/data/{provider}/{dataset}/', data=body)
         response.raise_for_status()
 
         return response.json()


### PR DESCRIPTION
### Rationale
When trying to save a document into dataset/collection using `api.insert_data` method, getting exception outlined below. This PR should fix that.

````
Traceback (most recent call last):
  File "/Users/Vlad/Development/corva/dc-be-baker-huges-custom-metrics/debug.py", line 82, in <module>
    run(
  File "/Users/Vlad/Development/corva/dc-be-baker-huges-custom-metrics/debug.py", line 77, in run
    data_processor.process_next_records(api_client=api, event=event)
  File "/Users/Vlad/Development/corva/dc-be-baker-huges-custom-metrics/src/data_processor.py", line 56, in process_next_records
    response = api_client.insert_data(
  File "/Users/Vlad/Development/virtualenvs/dc-be-baker-huges-custom-metrics/lib/python3.9/site-packages/corva/api.py", line 235, in insert_data
    response = self.post(f'/api/v1/data/{provider}/{dataset}/', json=body)
  File "/Users/Vlad/Development/virtualenvs/dc-be-baker-huges-custom-metrics/lib/python3.9/site-packages/corva/api.py", line 46, in post
    return self._request('POST', path, **kwargs)
TypeError: _request() got an unexpected keyword argument 'json'

Process finished with exit code 1
````
### Changes
Changed keyword argument name to the correct one. With this change method works.

