### PR TITLE
Adding retries on HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+-  Added functionality to make retries for the failed HTTP requests.
 
 
 # [1.10.0] - 2023-11-08

--- a/docs/modules/ROOT/examples/api/tutorial008.py
+++ b/docs/modules/ROOT/examples/api/tutorial008.py
@@ -1,0 +1,7 @@
+from corva import Api, Cache, ScheduledDataTimeEvent, ScheduledDepthEvent, scheduled
+
+
+@scheduled
+def scheduled_app(event: ScheduledDataTimeEvent, api: Api, cache: Cache):
+    api.max_retries = 5  # Enabling up to 5 retries when HTTP error happens.
+    ...

--- a/docs/modules/ROOT/examples/api/tutorial008.py
+++ b/docs/modules/ROOT/examples/api/tutorial008.py
@@ -1,4 +1,4 @@
-from corva import Api, Cache, ScheduledDataTimeEvent, ScheduledDepthEvent, scheduled
+from corva import Api, Cache, ScheduledDataTimeEvent, scheduled
 
 
 @scheduled

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -269,6 +269,22 @@ include::example$api/tutorial007.py[]
 <.> You can enable this flag
 to save and <<produce_messages,`produce`>> the data at once.
 
+[#enabling_retries]
+=== Enabling re-tries
+
+When request fails due to HTTP error, re-trying functionality can be used.
+It will try to re-send the same request again with exponential back-off for HTTP status codes below:
+
+* 428
+* 500
+* 502
+* 503
+* 504
+
+[source,python]
+----
+include::example$api/tutorial008.py[]
+
 [#cache]
 == Cache
 Apps might need to share some data between invokes.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -284,6 +284,7 @@ It will try to re-send the same request again with exponential back-off for HTTP
 [source,python]
 ----
 include::example$api/tutorial008.py[]
+----
 
 [#cache]
 == Cache

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
         "redis >=3.5.3, <4.0.0",
         "requests >=2.25.0, <3.0.0",
         "urllib3 <2",  # lambda doesnt support version 2 yet
+        "pydantic >=8.2.3, <9.0.0"
     ],
     python_requires='>=3.8, <4.0',
     license='The Unlicense',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
         "redis >=3.5.3, <4.0.0",
         "requests >=2.25.0, <3.0.0",
         "urllib3 <2",  # lambda doesnt support version 2 yet
-        "pydantic >=8.2.3, <9.0.0"
+        "tenacity >=8.2.3, <9.0.0",
     ],
     python_requires='>=3.8, <4.0',
     license='The Unlicense',

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -16,7 +16,7 @@ class Api:
     """
 
     TIMEOUT_LIMITS = (3, 30)  # seconds
-    DEFAULT_MAX_RETRIES = 0
+    DEFAULT_MAX_RETRIES = int(0)
     HTTP_STATUS_CODES_TO_RETRY = [
         HTTPStatus.TOO_MANY_REQUESTS,  # 428
         HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
@@ -51,12 +51,12 @@ class Api:
         }
 
     @property
-    def max_retries(self):
+    def max_retries(self) -> int:
         return self._max_retries
 
     @max_retries.setter
-    def max_retries(self, value):
-        if not (isinstance(value, int) and 0 <= value <= 10):
+    def max_retries(self, value: int):
+        if not (0 <= value <= 10):
             raise ValueError("Values between 0 and 10 are allowed")
         self._max_retries = value
 
@@ -147,7 +147,7 @@ class Api:
             if response.status_code not in self.HTTP_STATUS_CODES_TO_RETRY:
                 break
             if self._max_retries:
-                time.sleep(2**retry_attempt / 4)  # 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, ...
+                time.sleep(2**retry_attempt / 4)  # 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, ...
 
         return response
 

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -101,12 +101,12 @@ class Api:
 
     @staticmethod
     def _execute_request(
-            method: str,
-            url: str,
-            params: Optional[dict],
-            data: Optional[dict],
-            headers: Optional[dict] = None,
-            timeout: Optional[int] = None
+        method: str,
+        url: str,
+        params: Optional[dict],
+        data: Optional[dict],
+        headers: Optional[dict] = None,
+        timeout: Optional[int] = None,
     ):
         """Executes the request.
 
@@ -175,18 +175,34 @@ class Api:
             retry_decorator = retry(
                 stop=stop_after_attempt(self.max_retries),
                 wait=wait_random_exponential(multiplier=0.25, max=10),
-                retry=retry_if_result(lambda r: r.status_code in retryable_status_codes)
+                retry=retry_if_result(
+                    lambda r: r.status_code in retryable_status_codes
+                ),
             )
             retrying_request = retry_decorator(self._execute_request)
             try:
-                response = retrying_request(method, url, params, data, headers, timeout)
+                response = retrying_request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    data=data,
+                    headers=headers,
+                    timeout=timeout,
+                )
             except RetryError as e:
                 if not e.last_attempt.failed:
                     response = e.last_attempt.result()
                 else:
                     raise
         else:
-            response = self._execute_request(method, url, params, data, headers, timeout)
+            response = self._execute_request(
+                method=method,
+                url=url,
+                params=params,
+                data=data,
+                headers=headers,
+                timeout=timeout,
+            )
 
         return response
 

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -18,11 +18,11 @@ class Api:
     TIMEOUT_LIMITS = (3, 30)  # seconds
     DEFAULT_MAX_RETRIES = 5
     HTTP_STATUS_CODES_TO_RETRY = [
-        HTTPStatus.TOO_MANY_REQUESTS,       # 428
-        HTTPStatus.INTERNAL_SERVER_ERROR,   # 500
-        HTTPStatus.BAD_GATEWAY,             # 502
-        HTTPStatus.SERVICE_UNAVAILABLE,     # 503
-        HTTPStatus.GATEWAY_TIMEOUT          # 504
+        HTTPStatus.TOO_MANY_REQUESTS,  # 428
+        HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
+        HTTPStatus.BAD_GATEWAY,  # 502
+        HTTPStatus.SERVICE_UNAVAILABLE,  # 503
+        HTTPStatus.GATEWAY_TIMEOUT,  # 504
     ]
 
     def __init__(
@@ -46,24 +46,24 @@ class Api:
     @property
     def default_headers(self):
         return {
-            'Authorization': f'API {self.api_key}',
-            'X-Corva-App': self.app_key,
+            "Authorization": f"API {self.api_key}",
+            "X-Corva-App": self.app_key,
         }
 
     def get(self, path: str, **kwargs):
-        return self._request('GET', path, **kwargs)
+        return self._request("GET", path, **kwargs)
 
     def post(self, path: str, **kwargs):
-        return self._request('POST', path, **kwargs)
+        return self._request("POST", path, **kwargs)
 
     def patch(self, path: str, **kwargs):
-        return self._request('PATCH', path, **kwargs)
+        return self._request("PATCH", path, **kwargs)
 
     def put(self, path: str, **kwargs):
-        return self._request('PUT', path, **kwargs)
+        return self._request("PUT", path, **kwargs)
 
     def delete(self, path: str, **kwargs):
-        return self._request('DELETE', path, **kwargs)
+        return self._request("DELETE", path, **kwargs)
 
     def _get_url(self, path: str):
         """Builds complete url.
@@ -77,15 +77,15 @@ class Api:
           3 corva api url, if above points are False.
         """
 
-        if path.startswith('http'):
+        if path.startswith("http"):
             return path
 
         path = path.lstrip(
-            '/'
+            "/"
         )  # delete leading forward slash for posixpath.join to work correctly
 
         # search text like api/v1 or api/v10 in path
-        if bool(re.search(r'api/v\d+', path)):
+        if bool(re.search(r"api/v\d+", path)):
             return posixpath.join(self.data_api_url, path)
 
         return posixpath.join(self.api_url, path)
@@ -136,15 +136,15 @@ class Api:
             )
             if response.status_code not in self.HTTP_STATUS_CODES_TO_RETRY:
                 break
-            time.sleep(2 ** retry_attempt / 4)
+            time.sleep(2**retry_attempt / 4)
 
         return response
 
     def _validate_timeout(self, timeout: int) -> None:
         if self.TIMEOUT_LIMITS[0] > timeout or self.TIMEOUT_LIMITS[1] < timeout:
             raise ValueError(
-                f'Timeout must be between {self.TIMEOUT_LIMITS[0]} and '
-                f'{self.TIMEOUT_LIMITS[1]} seconds.'
+                f"Timeout must be between {self.TIMEOUT_LIMITS[0]} and "
+                f"{self.TIMEOUT_LIMITS[1]} seconds."
             )
 
     def get_dataset(
@@ -182,13 +182,13 @@ class Api:
         """
 
         response = self.get(
-            f'/api/v1/data/{provider}/{dataset}/',
+            f"/api/v1/data/{provider}/{dataset}/",
             params={
-                'query': json.dumps(query),
-                'sort': json.dumps(sort),
-                'fields': fields,
-                'limit': limit,
-                'skip': skip,
+                "query": json.dumps(query),
+                "sort": json.dumps(sort),
+                "fields": fields,
+                "limit": limit,
+                "skip": skip,
             },
         )
         response.raise_for_status()
@@ -211,8 +211,8 @@ class Api:
         """
 
         response = self.post(
-            '/api/v1/message_producer/',
-            json={'app_connection_id': self.app_connection_id, 'data': data},
+            "/api/v1/message_producer/",
+            json={"app_connection_id": self.app_connection_id, "data": data},
         )
         response.raise_for_status()
 
@@ -242,13 +242,13 @@ class Api:
 
         if produce:
             body = {
-                'data': list(data),
-                'producer': {'app_connection_id': self.app_connection_id},
+                "data": list(data),
+                "producer": {"app_connection_id": self.app_connection_id},
             }
         else:
             body = list(data)
 
-        response = self.post(f'/api/v1/data/{provider}/{dataset}/', data=body)
+        response = self.post(f"/api/v1/data/{provider}/{dataset}/", data=body)
         response.raise_for_status()
 
         return response.json()

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -5,7 +5,13 @@ from http import HTTPStatus
 from typing import List, Optional, Sequence, Union
 
 import requests
-from tenacity import retry, stop_after_attempt, wait_random_exponential, retry_if_result, RetryError
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_result,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 
 class Api:

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -278,7 +278,7 @@ class Api:
 
         response = self.post(
             "/api/v1/message_producer/",
-            json={"app_connection_id": self.app_connection_id, "data": data},
+            data={"app_connection_id": self.app_connection_id, "data": data},
         )
         response.raise_for_status()
 

--- a/src/corva/api.py
+++ b/src/corva/api.py
@@ -16,7 +16,7 @@ class Api:
     """
 
     TIMEOUT_LIMITS = (3, 30)  # seconds
-    DEFAULT_MAX_RETRIES = 5
+    DEFAULT_MAX_RETRIES = 0
     HTTP_STATUS_CODES_TO_RETRY = [
         HTTPStatus.TOO_MANY_REQUESTS,  # 428
         HTTPStatus.INTERNAL_SERVER_ERROR,  # 500

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,6 +1,8 @@
 import contextlib
 import json
+import time
 import urllib.parse
+from http import HTTPStatus
 
 import pytest
 import requests
@@ -17,7 +19,7 @@ def app(event, api):
     return api
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def api(app_runner) -> Api:
     """Returns Api instance from task app."""
 
@@ -29,23 +31,23 @@ def api(app_runner) -> Api:
 def test_request_default_headers(api, requests_mock: RequestsMocker):
     # do some api call
     requests_mock.get(
-        '',
+        "",
         request_headers={
-            'Authorization': f'API {api.api_key}',
-            'X-Corva-App': api.app_key,
+            "Authorization": f"API {api.api_key}",
+            "X-Corva-App": api.app_key,
         },
     )
-    api.get('')
+    api.get("")
 
 
 @pytest.mark.parametrize(
-    'path,expected',
+    "path,expected",
     [
-        ['http://localhost', 'http://localhost'],
-        ['api/v10/path', f'{SETTINGS.DATA_API_ROOT_URL}/api/v10/path'],
-        ['/api/v10/path', f'{SETTINGS.DATA_API_ROOT_URL}/api/v10/path'],
-        ['v10/path', f'{SETTINGS.API_ROOT_URL}/v10/path'],
-        ['/v10/path', f'{SETTINGS.API_ROOT_URL}/v10/path'],
+        ["http://localhost", "http://localhost"],
+        ["api/v10/path", f"{SETTINGS.DATA_API_ROOT_URL}/api/v10/path"],
+        ["/api/v10/path", f"{SETTINGS.DATA_API_ROOT_URL}/api/v10/path"],
+        ["v10/path", f"{SETTINGS.API_ROOT_URL}/v10/path"],
+        ["/v10/path", f"{SETTINGS.API_ROOT_URL}/v10/path"],
     ],
 )
 def test_request_url(path, expected, api, requests_mock: RequestsMocker):
@@ -54,20 +56,20 @@ def test_request_url(path, expected, api, requests_mock: RequestsMocker):
 
 
 def test_request_data_param_passed_as_json(api, requests_mock: RequestsMocker):
-    post_mock = requests_mock.post('')
-    api.post('', data={})
-    assert post_mock.last_request._request.body.decode() == '{}'
+    post_mock = requests_mock.post("")
+    api.post("", data={})
+    assert post_mock.last_request._request.body.decode() == "{}"
 
 
 def test_request_additional_headers(api, requests_mock: RequestsMocker):
-    custom_headers = {'custom': 'value'}
+    custom_headers = {"custom": "value"}
 
-    requests_mock.post('', request_headers={**api.default_headers, **custom_headers})
-    api.post('', headers={'custom': 'value'})
+    requests_mock.post("", request_headers={**api.default_headers, **custom_headers})
+    api.post("", headers={"custom": "value"})
 
 
 @pytest.mark.parametrize(
-    'timeout, exc_ctx',
+    "timeout, exc_ctx",
     [
         (3, contextlib.nullcontext()),
         (30, contextlib.nullcontext()),
@@ -76,22 +78,22 @@ def test_request_additional_headers(api, requests_mock: RequestsMocker):
     ],
 )
 def test_request_timeout_limits(timeout, exc_ctx, api, requests_mock: RequestsMocker):
-    requests_mock.post('')
+    requests_mock.post("")
 
     with exc_ctx:
-        api.post('', timeout=timeout)
+        api.post("", timeout=timeout)
 
 
 @pytest.mark.parametrize(
-    'fields,skip,limit,query,sort',
+    "fields,skip,limit,query,sort",
     (
         [None, 0, 1, {}, {}],
         [
-            '_id',
+            "_id",
             1,
             2,
-            {'k1': 'v1'},
-            {'k2': 'v2'},
+            {"k1": "v1"},
+            {"k2": "v2"},
         ],
     ),
 )
@@ -105,20 +107,20 @@ def test_get_dataset(
     requests_mock: RequestsMocker,
 ):
     provider = SETTINGS.PROVIDER
-    dataset = 'dataset'
+    dataset = "dataset"
 
     qs = urllib.parse.urlencode(
         {
-            'query': json.dumps(query),
-            'sort': json.dumps(sort),
-            **({'fields': fields} if fields else {}),
-            'limit': limit,
-            'skip': skip,
+            "query": json.dumps(query),
+            "sort": json.dumps(sort),
+            **({"fields": fields} if fields else {}),
+            "limit": limit,
+            "skip": skip,
         }
     )
 
     requests_mock.get(
-        f'/api/v1/data/{provider}/{dataset}/?{qs}', complete_qs=True, text='[{}]'
+        f"/api/v1/data/{provider}/{dataset}/?{qs}", complete_qs=True, text="[{}]"
     )
 
     result = api.get_dataset(
@@ -136,10 +138,10 @@ def test_get_dataset(
 
 def test_get_dataset_raises(api, requests_mock: RequestsMocker):
     provider = SETTINGS.PROVIDER
-    dataset = 'dataset'
+    dataset = "dataset"
 
     requests_mock.get(
-        f'/api/v1/data/{provider}/{dataset}/',
+        f"/api/v1/data/{provider}/{dataset}/",
         status_code=400,
     )
 
@@ -152,3 +154,73 @@ def test_get_dataset_raises(api, requests_mock: RequestsMocker):
         sort={},
         limit=1,
     )
+
+
+def test_retrying_logic_works_as_expected(api, requests_mock: RequestsMocker):
+    path = "/"
+    url = f"{SETTINGS.API_ROOT_URL}{path}"
+
+    bad_requests_statuses_codes = [
+        HTTPStatus.TOO_MANY_REQUESTS,
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        HTTPStatus.BAD_GATEWAY,
+    ]
+    good_requests_statuses_codes = [HTTPStatus.OK]
+
+    requests_sequence_return_status_codes = (
+        bad_requests_statuses_codes + good_requests_statuses_codes
+    )
+
+    requests_mock.register_uri(
+        "GET",
+        url,
+        [
+            {"status_code": int(status_code)}
+            for status_code in requests_sequence_return_status_codes
+        ],
+    )
+
+    start_time = time.time()
+    response = api.get(path)
+    end_time = time.time()
+
+    assert response.status_code in good_requests_statuses_codes
+    assert len(requests_mock.request_history) == len(
+        requests_sequence_return_status_codes
+    )
+    assert end_time - start_time > 1, (
+        f"At least 1 second retry delay should be applied for "
+        f"{len(bad_requests_statuses_codes)} retries."
+    )
+
+
+def test_retrying_logic_for_custom_max_retries_makes_n_calls(
+    api, requests_mock: RequestsMocker
+):
+    custom_max_retries = 2
+    path = "/"
+    url = f"{SETTINGS.API_ROOT_URL}{path}"
+
+    bad_requests_statuses_codes = [
+        HTTPStatus.TOO_MANY_REQUESTS,
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        HTTPStatus.BAD_GATEWAY,
+    ]
+
+    requests_mock.register_uri(
+        "GET",
+        url,
+        [
+            {"status_code": int(status_code)}
+            for status_code in bad_requests_statuses_codes
+        ],
+    )
+
+    assert len(bad_requests_statuses_codes) >= custom_max_retries
+
+    api.max_retries = custom_max_retries
+    api.get(path)
+
+    assert (
+        len(requests_mock.request_history) == custom_max_retries
+    ), f"When all requests fail only {custom_max_retries} requests should be made."

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -222,4 +222,4 @@ def test_disabled_by_default_retrying_logic_works_as_expected(
 
     assert (
         len(requests_mock.request_history) == 1
-    ), f"For disabled by default retrying functionality only 1 request should happen."
+    ), "For disabled by default retrying functionality only 1 request should happen."

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -157,8 +157,7 @@ def test_get_dataset_raises(api, requests_mock: RequestsMocker):
 
 
 def test_enabled_retrying_logic_works_as_expected(api, requests_mock: RequestsMocker):
-    max_retries = 5
-    api.max_retries = max_retries
+    api.max_retries = 5  # Enabling retrying functionality to make up to 5 attempts.
     path = "/"
     url = f"{SETTINGS.API_ROOT_URL}{path}"
 
@@ -196,11 +195,9 @@ def test_enabled_retrying_logic_works_as_expected(api, requests_mock: RequestsMo
     )
 
 
-def test_retrying_logic_for_custom_max_retries_makes_n_calls(
+def test_disabled_by_default_retrying_logic_works_as_expected(
     api, requests_mock: RequestsMocker
 ):
-    max_retries = 2
-    api.max_retries = max_retries
     path = "/"
     url = f"{SETTINGS.API_ROOT_URL}{path}"
 
@@ -219,10 +216,10 @@ def test_retrying_logic_for_custom_max_retries_makes_n_calls(
         ],
     )
 
-    assert len(bad_requests_statuses_codes) >= max_retries
+    assert len(bad_requests_statuses_codes) > 0
 
     api.get(path)
 
     assert (
-        len(requests_mock.request_history) == max_retries
-    ), f"When all requests fail only {max_retries} requests should be made."
+        len(requests_mock.request_history) == 1
+    ), f"For disabled by default retrying functionality only 1 request should happen."

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -156,7 +156,9 @@ def test_get_dataset_raises(api, requests_mock: RequestsMocker):
     )
 
 
-def test_retrying_logic_works_as_expected(api, requests_mock: RequestsMocker):
+def test_enabled_retrying_logic_works_as_expected(api, requests_mock: RequestsMocker):
+    max_retries = 5
+    api.max_retries = max_retries
     path = "/"
     url = f"{SETTINGS.API_ROOT_URL}{path}"
 
@@ -197,7 +199,8 @@ def test_retrying_logic_works_as_expected(api, requests_mock: RequestsMocker):
 def test_retrying_logic_for_custom_max_retries_makes_n_calls(
     api, requests_mock: RequestsMocker
 ):
-    custom_max_retries = 2
+    max_retries = 2
+    api.max_retries = max_retries
     path = "/"
     url = f"{SETTINGS.API_ROOT_URL}{path}"
 
@@ -216,11 +219,10 @@ def test_retrying_logic_for_custom_max_retries_makes_n_calls(
         ],
     )
 
-    assert len(bad_requests_statuses_codes) >= custom_max_retries
+    assert len(bad_requests_statuses_codes) >= max_retries
 
-    api.max_retries = custom_max_retries
     api.get(path)
 
     assert (
-        len(requests_mock.request_history) == custom_max_retries
-    ), f"When all requests fail only {custom_max_retries} requests should be made."
+        len(requests_mock.request_history) == max_retries
+    ), f"When all requests fail only {max_retries} requests should be made."

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -156,6 +156,19 @@ def test_get_dataset_raises(api, requests_mock: RequestsMocker):
     )
 
 
+def test_produce_messages_raises(api, requests_mock: RequestsMocker):
+    requests_mock.post(
+        "/api/v1/message_producer/",
+        status_code=400,
+    )
+
+    pytest.raises(
+        requests.HTTPError,
+        api.produce_messages,
+        data={},
+    )
+
+
 def test_disabled_by_default_retrying_logic_works_as_expected(
     api, requests_mock: RequestsMocker
 ):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -187,8 +187,7 @@ def test_disabled_by_default_retrying_logic_works_as_expected(
 
 
 def test_enabled_retrying_logic_with_all_failed_retries_returns_http_response_object(
-        api,
-        requests_mock: RequestsMocker
+    api, requests_mock: RequestsMocker
 ):
     api.max_retries = 1
     path = "/"

--- a/tests/unit/test_docs/test_api.py
+++ b/tests/unit/test_docs/test_api.py
@@ -127,6 +127,4 @@ def test_tutorial008(app_runner, mocker: MockerFixture):
     time_event = ScheduledDataTimeEvent(
         asset_id=0, company_id=0, start_time=0, end_time=0
     )
-    time_mock = mocker.patch.object(Api, 'insert_data')
     app_runner(tutorial008.scheduled_app, time_event)
-    time_mock.assert_not_called()

--- a/tests/unit/test_docs/test_api.py
+++ b/tests/unit/test_docs/test_api.py
@@ -15,6 +15,7 @@ from docs.modules.ROOT.examples.api import (
     tutorial005,
     tutorial006,
     tutorial007,
+    tutorial008,
 )
 
 
@@ -120,3 +121,12 @@ def test_tutorial007(app_runner, mocker: MockerFixture):
     time_mock = mocker.patch.object(Api, 'insert_data')
     app_runner(tutorial007.scheduled_app, time_event)
     time_mock.assert_called_once()
+
+
+def test_tutorial008(app_runner, mocker: MockerFixture):
+    time_event = ScheduledDataTimeEvent(
+        asset_id=0, company_id=0, start_time=0, end_time=0
+    )
+    time_mock = mocker.patch.object(Api, 'insert_data')
+    app_runner(tutorial008.scheduled_app, time_event)
+    time_mock.assert_not_called()


### PR DESCRIPTION
### Rationale
Currently API client does not make retries on server errors. This PR changes that.

### Changes
*Describe what you changed*


[JIRA ticket](put the link to the corresponding JIRA ticket here)

#### TODO
- [ ] Update CHANGELOG.md
