### PR TITLE
DEVC-627 | Handle optional data field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- For stream events data field can be None, not empty object.
+### Fixed
+- Filter out records with `None` data from stream time records.
 
 
 ## [1.11.2] - 2024-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- For stream events data field can be None, not empty object.
 
 
 ## [1.11.2] - 2024-01-05

--- a/src/corva/models/stream/raw.py
+++ b/src/corva/models/stream/raw.py
@@ -148,7 +148,7 @@ class RawStreamEvent(CorvaBaseEvent, RawBaseEvent):
     ) -> List[RawBaseRecord]:
         new_records = copy.deepcopy(self.records)
 
-        if self.is_completed and new_records:
+        if self.is_completed:
             new_records = new_records[:-1]  # remove "completed" record
 
         if old_max_record_value is None:

--- a/src/corva/models/stream/raw.py
+++ b/src/corva/models/stream/raw.py
@@ -19,7 +19,7 @@ class RawBaseRecord(CorvaBaseEvent, abc.ABC):
     company_id: int
     collection: str
 
-    data: dict = {}
+    data: Optional[dict] = {}
     metadata: dict = {}
 
     @property

--- a/src/corva/models/stream/stream.py
+++ b/src/corva/models/stream/stream.py
@@ -16,7 +16,7 @@ class StreamTimeRecord(CorvaBaseEvent):
     """
 
     timestamp: int
-    data: Optional[dict] = {}
+    data: dict = {}
     metadata: dict = {}
 
 

--- a/src/corva/models/stream/stream.py
+++ b/src/corva/models/stream/stream.py
@@ -16,7 +16,7 @@ class StreamTimeRecord(CorvaBaseEvent):
     """
 
     timestamp: int
-    data: dict = {}
+    data: Optional[dict] = {}
     metadata: dict = {}
 
 

--- a/tests/unit/test_stream_app.py
+++ b/tests/unit/test_stream_app.py
@@ -615,3 +615,40 @@ def test_stream_depth_app_gets_log_identifier(context):
     result_event: StreamDepthEvent = stream_app(event, context)[0]
 
     assert result_event.log_identifier == 'log_identifier'
+
+
+def test_raw_stream_event_with_none_data_field_returns_expected_result(context):
+    """Make sure that raw stream event with empty data field
+    can be handled without validation exception.
+    """
+
+    @stream
+    def stream_app(event, api, cache):
+        return event
+
+    event = [
+        {
+            "metadata": {
+                "app_stream_id": 123,
+                "apps": {"test-provider.test-app-name": {"app_connection_id": 456}},
+                "log_type": "time",
+                "source_type": "drilling",
+            },
+            "records": [
+                {
+                    "app": "corva.wits-historical-import",
+                    "asset_id": 1,
+                    "collection": "wits.completed",
+                    "company_id": 80,
+                    "data": None,
+                    "provider": "corva",
+                    "timestamp": 1688999883,
+                    "version": 1,
+                }
+            ],
+        }
+    ]
+
+    result_event: StreamTimeEvent = stream_app(event, context)[0]
+
+    assert result_event is None

--- a/tests/unit/test_stream_app.py
+++ b/tests/unit/test_stream_app.py
@@ -624,7 +624,10 @@ def test_raw_stream_event_with_none_data_field_returns_expected_result(context):
 
     @stream
     def stream_app(event, api, cache):
-        return event
+        pytest.fail(
+            "Stream app call should be skipped "
+            "because there is no data to build an event"
+        )
 
     event = [
         {
@@ -644,11 +647,10 @@ def test_raw_stream_event_with_none_data_field_returns_expected_result(context):
                     "provider": "corva",
                     "timestamp": 1688999883,
                     "version": 1,
-                }
+                }  # DEVC-627. This record should be filtered out because data is None.
             ],
         }
     ]
 
-    result_event: StreamTimeEvent = stream_app(event, context)[0]
-
-    assert result_event is None
+    _ = stream_app(event, context)[0]
+    assert True, "App call should be skipped"


### PR DESCRIPTION
### Rationale
Some old apps send events with empty data field which causes error like [this one](https://app.rollbar.com/a/corva/fix/item/Corva-Predictive-Drilling/61).

### Changes
Going forward, once event with empty data is received, no payload validation is raised.


[DEVC-627](https://corvaqa.atlassian.net/browse/DEVC-627)

#### TODO
- [x] Update CHANGELOG.md


[DEVC-627]: https://corvaqa.atlassian.net/browse/DEVC-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ