### PR TITLE
DRE-875 | Removing misleading validation for partial re-run version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Now "version" field represents not schema version but rather the version of rerun and can be any integer.
 
 
 ## [1.11.3] - 2024-02-07

--- a/src/corva/models/merge/raw.py
+++ b/src/corva/models/merge/raw.py
@@ -17,9 +17,7 @@ class RawPartialMergeEventData(pydantic.BaseModel):
     rerun_asset_id: int
     app_stream_id: int
     rerun_app_stream_id: int
-    version: int = pydantic.Field(
-        ..., le=1, ge=1
-    )  # Currently handler supports only 1-st version of this event.
+    version: int  # Partial re-run version
     app_id: Optional[int]
     app_key: Optional[str]
     app_connection_id: int

--- a/tests/unit/test_partial_rerun_merge_app.py
+++ b/tests/unit/test_partial_rerun_merge_app.py
@@ -20,7 +20,7 @@ RAW_EVENT = {
         "rerun_asset_id": 2323245,
         "app_stream_id": 9585,
         "rerun_app_stream_id": 4745,
-        "version": 1,
+        "version": 2,  # That is the partial re-run version, not schema version.
         "app_id": 46,
         "app_key": "corva.enrichment-wrapper",
         "app_connection_id": 2457,


### PR DESCRIPTION
### Rationale
Currently processing of valid payloads causes ValidationError because of too strict validation rule for "version" field.
https://app.rollbar.com/a/corva/fix/item/Corva-Slide-sheet/101

### Changes
Going forward "version" field represents not schema version but rather the version of rerun and can be any integer.


[DRE-875](https://corvaqa.atlassian.net/browse/DRE-875)

#### TODO
- [x] Update CHANGELOG.md


[DRE-875]: https://corvaqa.atlassian.net/browse/DRE-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ