### PR TITLE
[PoC] Possible improvements for robust SDK testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,20 @@ jobs:
         run: make lint
 
   test:
-    name: Automated testing
-
+    name: Automated Testing on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
       - name: Install
         run: make install-test

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ integration-tests:
 .PHONY: coverage
 coverage: test
 	@coverage combine
-	@coverage report
+	@coverage report --sort=cover
 
 ## coverage-html: Display code coverage in the browser.
 .PHONY: coverage-html

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 coverage==5.3
 freezegun==1.0.0
-pytest==6.1.2
+pytest==6.2.5
 pytest-mock==3.3.1
 requests-mock==1.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ show_missing = True
 exclude_lines =
     @abc.abstractmethod
     if TYPE_CHECKING
+    class .*Protocol.*
 omit =
     docs/modules/ROOT/examples/logging/tutorial003.py
     docs/modules/ROOT/examples/logging/tutorial004.py

--- a/tests/unit/state/test_redis_state.py
+++ b/tests/unit/state/test_redis_state.py
@@ -48,6 +48,21 @@ def test_delete(redis):
         mock_func.assert_called_once_with(keys=['1'], name=None)
 
 
+def test__user_redis_cache__main_methods_works(redis):
+    redis.set(key='key1', value='text1')
+    redis.set(key='key2', value='text2')
+    redis.set(key='key3', value='text3')
+
+    assert redis.get(key='key1') == 'text1'
+    assert redis.get_many(keys=['key2', 'key3']) == {'key2': 'text2', 'key3': 'text3'}
+
+    redis.delete(key='key1')
+    assert redis.get(key='key1') is None
+
+    redis.delete_many(keys=['key2', 'key3'])
+    assert redis.get_many(keys=['key2', 'key3']) == {'key2': None, 'key3': None}
+
+
 def test_exists(redis):
     with patch.object(redis.old_cache_repo, 'exists') as mock_func:
         redis.exists(*NAMES)

--- a/tests/unit/state/test_redis_state.py
+++ b/tests/unit/state/test_redis_state.py
@@ -48,21 +48,6 @@ def test_delete(redis):
         mock_func.assert_called_once_with(keys=['1'], name=None)
 
 
-def test__user_redis_cache__main_methods_works(redis):
-    redis.set(key='key1', value='text1')
-    redis.set(key='key2', value='text2')
-    redis.set(key='key3', value='text3')
-
-    assert redis.get(key='key1') == 'text1'
-    assert redis.get_many(keys=['key2', 'key3']) == {'key2': 'text2', 'key3': 'text3'}
-
-    redis.delete(key='key1')
-    assert redis.get(key='key1') is None
-
-    redis.delete_many(keys=['key2', 'key3'])
-    assert redis.get_many(keys=['key2', 'key3']) == {'key2': None, 'key3': None}
-
-
 def test_exists(redis):
     with patch.object(redis.old_cache_repo, 'exists') as mock_func:
         redis.exists(*NAMES)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -278,9 +278,7 @@ def test__trying_to_set_wrong_max_retries__value_error_raised(api):
 def test__app_insert_data__improves_coverage(api, requests_mock: RequestsMocker):
 
     post_mock = requests_mock.post(
-        re.compile('/api/v1/data/'),
-        status_code=200,
-        json={}
+        re.compile('/api/v1/data/'), status_code=200, json={}
     )
 
     api.insert_data(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -277,7 +277,11 @@ def test__trying_to_set_wrong_max_retries__value_error_raised(api):
 
 def test__app_insert_data__improves_coverage(api, requests_mock: RequestsMocker):
 
-    post_mock = requests_mock.post(re.compile('/api/v1/data/'), status_code=200, json={})
+    post_mock = requests_mock.post(
+        re.compile('/api/v1/data/'),
+        status_code=200,
+        json={}
+    )
 
     api.insert_data(
         provider='any',

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import re
 import time
 import urllib.parse
 from http import HTTPStatus
@@ -267,3 +268,21 @@ def test_enabled_retrying_logic_works_as_expected(api, requests_mock: RequestsMo
         f"At least 1 second retry delay should be applied for "
         f"{len(bad_requests_statuses_codes)} retries."
     )
+
+
+def test__trying_to_set_wrong_max_retries__value_error_raised(api):
+    with pytest.raises(ValueError):
+        api.max_retries = 15
+
+
+def test__app_insert_data__improves_coverage(api, requests_mock: RequestsMocker):
+
+    post_mock = requests_mock.post(re.compile('/api/v1/data/'), status_code=200, json={})
+
+    api.insert_data(
+        provider='any',
+        dataset='any',
+        data=[{'any': 'any'}, {'any': 'any'}],
+    )
+
+    assert post_mock.called_once is True


### PR DESCRIPTION
### Rationale
To make more robust and stable software, we can add automated tests for corva python SDK on different Python versions to make sure that SDK works well with apps written on `py3.8...3.11`
To be honest, after some research, I've noticed that we have all `3.8` | `3.9` | `3.10` | `3.11` Python versions used for apps 😨 

### Changes
- GitHub workflow matrix used
- pytest version bumped from `6.1.2` to `6.2.5` to fix [described here](https://github.com/pytest-dev/pytest/discussions/9195) issue 


[JIRA ticket](put the link to the corresponding JIRA ticket here)

#### TODO
- [ ] Update CHANGELOG.md
