### PR TITLE
fix: [CINF-4627] fix project build after migration to pyproject

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,10 +110,10 @@ jobs:
           python-version: 3.9
 
       - name: Install dependencies
-        run: pip install -U setuptools wheel
+        run: pip install -U setuptools wheel build
 
       - name: Build the package
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2


### PR DESCRIPTION
### Rationale
Previous PR broke package building. 
https://github.com/corva-ai/python-sdk/actions/runs/17463236389/job/49592783571

This PR fixes it.

### Changes
Updated github workflow build step to use `build` instead of `setup.py`


